### PR TITLE
Switch Wrapped Environment

### DIFF
--- a/env.template
+++ b/env.template
@@ -1,1 +1,2 @@
 SHAPESHIFT_URI=https://app.shapeshift.com
+DEVELOP_URI=https://develop.shapeshift.com

--- a/env.template
+++ b/env.template
@@ -1,2 +1,3 @@
 SHAPESHIFT_URI=https://app.shapeshift.com
 DEVELOP_URI=https://develop.shapeshift.com
+RELEASE_URI=https://release.shapeshift.com

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-native": "0.69.3",
     "react-native-dotenv": "^3.3.1",
     "react-native-error-boundary": "^1.1.15",
+    "react-native-select-dropdown": "^2.0.4",
     "react-native-webview": "^11.23.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,10 @@ import { injectedJavaScript, onMessage } from './lib/console'
 import { MessageManager } from './lib/MessageManager'
 import { clearMnemonic, getMnemonic, hasMnemonic, setMnemonic } from './lib/mnemonicStore'
 import { shouldLoadFilter } from './lib/navigationFilter'
-import { SHAPESHIFT_URI } from 'react-native-dotenv'
+import { SHAPESHIFT_URI, DEVELOP_URI } from 'react-native-dotenv'
+import SelectDropdown from 'react-native-select-dropdown'
+
+const uris = [SHAPESHIFT_URI, DEVELOP_URI]
 
 /* Register message handlers and injected JavaScript */
 const messageManager = new MessageManager()
@@ -22,6 +25,7 @@ messageManager.on('setKey', setMnemonic)
 
 const App = () => {
   const [loading, setLoading] = useState(true)
+  const [ssUrl, setSsUrl] = useState(SHAPESHIFT_URI)
   const [error, setError] = useState(false)
   const webviewRef = useRef<WebView>(null)
   messageManager.setWebViewRef(webviewRef)
@@ -55,7 +59,7 @@ const App = () => {
           onLoad={() => setLoading(false)}
           onNavigationStateChange={e => console.log('Navigation Start', e.url)}
           onShouldStartLoadWithRequest={shouldLoadFilter}
-          source={{ uri: `${SHAPESHIFT_URI}/#/dashboard` }}
+          source={{ uri: `${ssUrl}/#/dashboard` }}
           onError={syntheticEvent => {
             const { nativeEvent } = syntheticEvent
             console.error('WebView onError: ', nativeEvent)
@@ -64,6 +68,15 @@ const App = () => {
           }}
         />
       </ErrorBoundary>
+      <SelectDropdown
+        data={uris}
+        defaultValue={SHAPESHIFT_URI}
+        onSelect={selectedItem => {
+          setSsUrl(selectedItem)
+        }}
+        buttonTextAfterSelection={selectedItem => selectedItem}
+        rowTextForSelection={item => item}
+      />
     </SafeAreaView>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react'
-import { ActivityIndicator, SafeAreaView } from 'react-native'
+import { ActivityIndicator, SafeAreaView, Text, View } from 'react-native'
 import { WebView } from 'react-native-webview'
 import ErrorBoundary from 'react-native-error-boundary'
 import ErrorPage from './ErrorPage'
@@ -11,7 +11,12 @@ import { shouldLoadFilter } from './lib/navigationFilter'
 import { SHAPESHIFT_URI, DEVELOP_URI } from 'react-native-dotenv'
 import SelectDropdown from 'react-native-select-dropdown'
 
-const uris = [SHAPESHIFT_URI, DEVELOP_URI]
+const uris = [
+  SHAPESHIFT_URI,
+  DEVELOP_URI,
+  // release v1.57.0
+  'https://bafybeigwr6g27qysprur3x6d3y76e6tpbe3j2n7v4jkcpvdhu7tqf72kx4.on.fleek.co',
+]
 
 /* Register message handlers and injected JavaScript */
 const messageManager = new MessageManager()
@@ -26,6 +31,7 @@ messageManager.on('setKey', setMnemonic)
 const App = () => {
   const [loading, setLoading] = useState(true)
   const [ssUrl, setSsUrl] = useState(SHAPESHIFT_URI)
+  const [devMode, setDevMode] = useState(false)
   const [error, setError] = useState(false)
   const webviewRef = useRef<WebView>(null)
   messageManager.setWebViewRef(webviewRef)
@@ -36,6 +42,15 @@ const App = () => {
 
   return (
     <SafeAreaView style={styles.container}>
+      <View>
+        <Text
+          onLongPress={() => {
+            setDevMode(true)
+          }}
+        >
+          SS
+        </Text>
+      </View>
       <ErrorBoundary
         onError={(e: Error) => {
           console.error(`ErrorBoundary onError: `, e)
@@ -68,15 +83,17 @@ const App = () => {
           }}
         />
       </ErrorBoundary>
-      <SelectDropdown
-        data={uris}
-        defaultValue={SHAPESHIFT_URI}
-        onSelect={selectedItem => {
-          setSsUrl(selectedItem)
-        }}
-        buttonTextAfterSelection={selectedItem => selectedItem}
-        rowTextForSelection={item => item}
-      />
+      <View style={[{ display: devMode ? 'flex' : 'none' }]}>
+        <SelectDropdown
+          data={uris}
+          defaultValue={SHAPESHIFT_URI}
+          onSelect={selectedItem => {
+            setSsUrl(selectedItem)
+          }}
+          buttonTextAfterSelection={selectedItem => selectedItem}
+          rowTextForSelection={item => item}
+        />
+      </View>
     </SafeAreaView>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,15 +8,10 @@ import { injectedJavaScript, onMessage } from './lib/console'
 import { MessageManager } from './lib/MessageManager'
 import { clearMnemonic, getMnemonic, hasMnemonic, setMnemonic } from './lib/mnemonicStore'
 import { shouldLoadFilter } from './lib/navigationFilter'
-import { SHAPESHIFT_URI, DEVELOP_URI } from 'react-native-dotenv'
+import { SHAPESHIFT_URI, DEVELOP_URI, RELEASE_URI } from 'react-native-dotenv'
 import SelectDropdown from 'react-native-select-dropdown'
 
-const uris = [
-  SHAPESHIFT_URI,
-  DEVELOP_URI,
-  // release v1.57.0
-  'https://bafybeigwr6g27qysprur3x6d3y76e6tpbe3j2n7v4jkcpvdhu7tqf72kx4.on.fleek.co',
-]
+const uris = [SHAPESHIFT_URI, DEVELOP_URI, RELEASE_URI]
 
 /* Register message handlers and injected JavaScript */
 const messageManager = new MessageManager()

--- a/src/lib/navigationFilter.ts
+++ b/src/lib/navigationFilter.ts
@@ -11,7 +11,11 @@ const openBrowser = async (url: string) => {
 
 export const shouldLoadFilter = (request: ShouldStartLoadRequest) => {
   // Navigation within wrapped web app
-  if (request.url.startsWith(SHAPESHIFT_URI) || request.url.startsWith(DEVELOP_URI)) {
+  if (
+    request.url.startsWith(SHAPESHIFT_URI) ||
+    request.url.startsWith(DEVELOP_URI) ||
+    request.url.includes('on.fleek.co') // FIXME
+  ) {
     return true
   }
 

--- a/src/lib/navigationFilter.ts
+++ b/src/lib/navigationFilter.ts
@@ -1,6 +1,6 @@
 import { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes'
 import { Linking } from 'react-native'
-import { SHAPESHIFT_URI } from 'react-native-dotenv'
+import { SHAPESHIFT_URI, DEVELOP_URI } from 'react-native-dotenv'
 
 const openBrowser = async (url: string) => {
   if (!(await Linking.canOpenURL(url))) {
@@ -11,9 +11,10 @@ const openBrowser = async (url: string) => {
 
 export const shouldLoadFilter = (request: ShouldStartLoadRequest) => {
   // Navigation within wrapped web app
-  if (request.url.startsWith(SHAPESHIFT_URI)) {
+  if (request.url.startsWith(SHAPESHIFT_URI) || request.url.startsWith(DEVELOP_URI)) {
     return true
   }
+
   // External navigation
   openBrowser(request.url).catch(r => {
     console.error(`rejection opening in browser url "${request.url}": `, r)

--- a/src/lib/navigationFilter.ts
+++ b/src/lib/navigationFilter.ts
@@ -1,6 +1,6 @@
 import { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes'
 import { Linking } from 'react-native'
-import { SHAPESHIFT_URI, DEVELOP_URI } from 'react-native-dotenv'
+import { SHAPESHIFT_URI, RELEASE_URI, DEVELOP_URI } from 'react-native-dotenv'
 
 const openBrowser = async (url: string) => {
   if (!(await Linking.canOpenURL(url))) {
@@ -14,7 +14,7 @@ export const shouldLoadFilter = (request: ShouldStartLoadRequest) => {
   if (
     request.url.startsWith(SHAPESHIFT_URI) ||
     request.url.startsWith(DEVELOP_URI) ||
-    request.url.includes('on.fleek.co') // FIXME
+    request.url.startsWith(RELEASE_URI)
   ) {
     return true
   }

--- a/src/types/react-native-dotenv.d.ts
+++ b/src/types/react-native-dotenv.d.ts
@@ -1,4 +1,5 @@
 declare module 'react-native-dotenv' {
   export const SHAPESHIFT_URI: string
+  export const RELEASE_URI: string
   export const DEVELOP_URI: string
 }

--- a/src/types/react-native-dotenv.d.ts
+++ b/src/types/react-native-dotenv.d.ts
@@ -1,3 +1,4 @@
 declare module 'react-native-dotenv' {
   export const SHAPESHIFT_URI: string
+  export const DEVELOP_URI: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7100,6 +7100,11 @@ react-native-gradle-plugin@^0.0.7:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz#96602f909745239deab7b589443f14fce5da2056"
   integrity sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==
 
+react-native-select-dropdown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-select-dropdown/-/react-native-select-dropdown-2.0.4.tgz#269d1d8d6228d511a2b82a4f110f2a6e655609dd"
+  integrity sha512-bv8iznvf04FThqCkkD4kxlbNjo2d69yLcEe3nUwalQ6ea2NXqUJRQ5uUr1SEDSCH8l6IQlmog8rkHthrLEzQ9A==
+
 react-native-webview@^11.23.0:
   version "11.23.0"
   resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.23.0.tgz#603a584236da2e993906e6a094f165dcac3a1fdb"


### PR DESCRIPTION
https://github.com/shapeshift/mobile-app/issues/30 First go at allowing switching the web app the mobile app wraps at runtime. In lieu of any visible components outside of the WebView, I added a small text `SS` in the top left. Long pressing that makes the unstyled select uri box visible. I also hard coded today's fleek release as a third option. we need to figure out a way to whitelist on.fleek.co urls.

![Screen Shot 2022-08-15 at 2 03 08 PM](https://user-images.githubusercontent.com/7322275/184719497-e5a6c2d5-9e60-4144-bc77-06b25e8167a9.png)
![Screen Shot 2022-08-15 at 2 03 34 PM](https://user-images.githubusercontent.com/7322275/184719905-8332efca-48bf-46f8-8d84-33c4b239f12d.png)

