### PR TITLE
feat: add showDeveloperModal listener and remove default shake event

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,12 +25,18 @@ const App = () => {
   const { startImport } = useImportWallet()
 
   useEffect(() => {
-    const subscription = RNShake.addListener(() => setIsDebugModalVisible(true))
+    messageManager.on('showDeveloperModal', evt => setIsDebugModalVisible(Boolean(evt.key)))
+  }, [messageManager])
+
+  useEffect(() => {
+    const subscription = RNShake.addListener(() => {
+      messageManager.postMessage({ cmd: 'shakeEvent' })
+    })
 
     return () => {
       subscription.remove()
     }
-  }, [])
+  }, [messageManager])
 
   useEffect(() => {
     const backHandler = BackHandler.addEventListener(


### PR DESCRIPTION
Add a message handler for `showDeveloperModal` so the web app can decide how to show it.

* Remove the shake handler to show the developer modal
* Send an event of `shakeEvent` to the webapp when a shake it detected
