### PR TITLE
Feat/biometrics

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.shapeshift">
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.CAMERA"/>
+  <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
+  <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
   <application
     android:name=".MainApplication"
     android:label="@string/app_name"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 31
         targetSdkVersion = 31
+        kotlinVersion = '1.6.10'
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
@@ -23,6 +24,7 @@ buildscript {
         classpath('com.android.tools.build:gradle:7.2.2')
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.0.1")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -38,3 +38,6 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
 newArchEnabled=false
+
+# See https://react-native-async-storage.github.io/async-storage/docs/advanced/next
+AsyncStorage_useNextStorage=true

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -12,6 +12,8 @@ PODS:
     - ExpoModulesCore
   - EXFont (10.2.0):
     - ExpoModulesCore
+  - EXLocalAuthentication (12.3.0):
+    - ExpoModulesCore
   - Expo (46.0.10):
     - ExpoModulesCore
   - ExpoKeepAwake (10.2.0):
@@ -417,6 +419,7 @@ DEPENDENCIES:
   - EXErrorRecovery (from `../node_modules/expo-error-recovery/ios`)
   - EXFileSystem (from `../node_modules/expo-file-system/ios`)
   - EXFont (from `../node_modules/expo-font/ios`)
+  - EXLocalAuthentication (from `../node_modules/expo-local-authentication/ios`)
   - Expo (from `../node_modules/expo`)
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
   - ExpoModulesCore (from `../node_modules/expo-modules-core/ios`)
@@ -520,6 +523,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-file-system/ios"
   EXFont:
     :path: "../node_modules/expo-font/ios"
+  EXLocalAuthentication:
+    :path: "../node_modules/expo-local-authentication/ios"
   Expo:
     :path: "../node_modules/expo"
   ExpoKeepAwake:
@@ -618,6 +623,7 @@ SPEC CHECKSUMS:
   EXErrorRecovery: 74d71ee59f6814315457b09d68e86aa95cc7d05d
   EXFileSystem: 927e0a8885aa9c49e50fc38eaba2c2389f2f1019
   EXFont: a5d80bd9b3452b2d5abbce2487da89b0150e6487
+  EXLocalAuthentication: a714f4e7370c4efba4ed4345a55110f22ac3d85f
   Expo: fcdb32274e2ca9c7638d3b21b30fb665c6869219
   ExpoKeepAwake: 0e8f18142e71bbf2c7f6aa66ebed249ba1420320
   ExpoModulesCore: 5a973701f4400d70254bc836305228731c829010

--- a/ios/shapeshift/Info.plist
+++ b/ios/shapeshift/Info.plist
@@ -39,6 +39,8 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Allow camera access to scan QR code</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Use face ID for wallet access</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>UIBackgroundModes</key>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@seald-io/react-native-scrypt": "^1.2.3",
     "bip39": "^3.0.4",
     "expo": "^46.0.10",
+    "expo-local-authentication": "^12.3.0",
     "expo-modules-autolinking": "^0.10.3",
     "expo-modules-core": "^0.11.5",
     "expo-secure-store": "^11.3.0",

--- a/src/hooks/useMessageManager.tsx
+++ b/src/hooks/useMessageManager.tsx
@@ -40,11 +40,11 @@ const useMessageManagerImpl = () => {
     messageManager.on('listWallets', () => walletManager.list())
     messageManager.on('hasWallets', () => walletManager.size > 0)
     messageManager.on('getWalletCount', () => walletManager.size)
-    messageManager.on('deleteWallet', evt => walletManager.delete(evt.key))
-    messageManager.on('getWallet', async evt => walletManager.get(evt.key))
+    messageManager.on('deleteWallet', evt => walletManager.deleteWallet(evt.key))
+    messageManager.on('getWallet', async evt => walletManager.getStoredWalletWithMnemonic(evt.key))
     messageManager.on('hasWallet', evt => walletManager.has(evt.key))
     messageManager.on('updateWallet', (evt: EventData) =>
-      walletManager.update(evt.key, { label: String(evt.label) }),
+      walletManager.updateStoredWallet(evt.key, { label: String(evt.label) }),
     )
     messageManager.on('addWallet', evt =>
       walletManager.add({

--- a/src/lib/Wallet.ts
+++ b/src/lib/Wallet.ts
@@ -2,14 +2,15 @@ export type StoredWallet = { id: string; label: string; createdAt: number }
 export type StoredMnemonic = { mnemonic: string }
 export type StoredWalletWithMnemonic = StoredWallet & StoredMnemonic
 
-
 export const isValidDeviceId = (deviceId: string) => /[a-z0-9-]+/.test(deviceId)
 export const isValidStoredWallet = (storedWallet: StoredWallet): boolean => {
-  return typeof storedWallet === 'object' &&
+  return (
+    typeof storedWallet === 'object' &&
     isValidDeviceId(storedWallet.id) &&
     // a cheap way to make sure the date is reasonable
     new Date(storedWallet.createdAt ?? Date.now()).valueOf() > 1600000000000 &&
     Boolean(storedWallet.label)
+  )
 }
 
 export const parseMnemonic = (mnemonic: unknown): string | null => {
@@ -28,12 +29,7 @@ export class Wallet {
   readonly #value: StoredWalletWithMnemonic
 
   constructor(wallet: StoredWalletWithMnemonic) {
-    if (
-      !(
-        isValidStoredWallet(wallet) &&
-        parseMnemonic(wallet.mnemonic)
-      )
-    ) {
+    if (!(isValidStoredWallet(wallet) && parseMnemonic(wallet.mnemonic))) {
       throw new Error('Invalid wallet')
     }
 
@@ -58,7 +54,7 @@ export class Wallet {
   }
 
   /**
-   * Returns non sensitive wallet meta-data only.  No mnemonic. 
+   * Returns non sensitive wallet meta-data only.  No mnemonic.
    */
   get storedWallet(): StoredWallet {
     return { id: this.#value.id, label: this.#value.label, createdAt: this.#value.createdAt }

--- a/src/lib/WalletManager.ts
+++ b/src/lib/WalletManager.ts
@@ -20,7 +20,6 @@ export class WalletManager {
   public async initialize() {
     try {
       if (this.#index.size === 0) {
-        console.log("init!!!!");
         const index: string[] = JSON.parse((await getItemAsync('mnemonic-index')) || '[]')
         this.#index = new Set(index)
       } else {
@@ -75,9 +74,7 @@ export class WalletManager {
   public async get(key: string) {
     if (this.has(key)) {
       try {
-        console.log("getting wallet!!! - get", key)
         const result = await getItemAsync(getKey(key))
-        console.log("got this"), result;
         if (result) return Wallet.fromJSON(result).toJSON()
       } catch (e) {
         // Delete a saved wallet if it's not valid
@@ -113,7 +110,6 @@ export class WalletManager {
   public async set(key: string, value: StoredWalletWithMnemonic, requireAuthentication: boolean = true): Promise<StoredWallet | null> {
     try {
       const wallet = new Wallet(value)
-      console.log("setting!", key);
       await setItemAsync(getKey(key), JSON.stringify(wallet.toJSON()), {
         keychainAccessible: WHEN_UNLOCKED,
         requireAuthentication
@@ -136,7 +132,6 @@ export class WalletManager {
       }
 
       for (const id of this.#index) {
-        console.log("updateIndex - get", id)
         const exists = await getItemAsync(getKey(id))
         // Use a key of '*' to delete all wallets
         if (!exists || (action === UpdateAction.REMOVE && (key === id || key === '*'))) {

--- a/src/lib/WalletManager.ts
+++ b/src/lib/WalletManager.ts
@@ -1,10 +1,17 @@
 import { deleteItemAsync, getItemAsync, setItemAsync, WHEN_UNLOCKED } from 'expo-secure-store'
+import { getEnrolledLevelAsync } from 'expo-local-authentication'
 import { decrypt } from './crypto'
-import { isValidDeviceId, StoredWallet, StoredWalletWithMnemonic, Wallet } from './Wallet'
+import { isValidDeviceId, isValidStoredWallet, parseMnemonic, StoredMnemonic, StoredWallet, StoredWalletWithMnemonic, Wallet } from './Wallet'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 
-const getKey = (key: string) => {
-  if (!isValidDeviceId(key)) throw new Error('Invalid key')
+const getMnemonicKey = (key: string) => {
+  if (!isValidDeviceId(key)) throw new Error('Invalid Mnemonic key')
   return `mnemonic_${key}`
+}
+
+const getWalletKey = (key: string) => {
+  if (!isValidDeviceId(key)) throw new Error('Invalid Wallet key')
+  return `wallet_${key}`
 }
 
 enum UpdateAction {
@@ -12,16 +19,22 @@ enum UpdateAction {
   REMOVE,
 }
 
+type StoredWalletsEntries = Array<[string, StoredWallet]>
+type StoredWalletsMap = Map<string, StoredWallet>
+
 export class WalletManager {
-  #index = new Set<string>()
+  #index: StoredWalletsMap = new Map()
+  #useAuthentication = false
 
   public readonly [Symbol.toStringTag]: string = 'WalletManager'
 
   public async initialize() {
     try {
       if (this.#index.size === 0) {
-        const index: string[] = JSON.parse((await getItemAsync('mnemonic-index')) || '[]')
-        this.#index = new Set(index)
+        const index: StoredWalletsEntries = JSON.parse(
+          (await AsyncStorage.getItem('mnemonic-index')) || '[]',
+        )
+        this.#index = new Map(index)
       } else {
         console.error('[WalletManager.initialize] initialize was already called')
       }
@@ -31,6 +44,15 @@ export class WalletManager {
       // We could end up with "lost" wallets, but I don't see a way to intelligently recover
       // from a failure to parse the stored JSON.
     }
+
+    try {
+      // https://docs.expo.dev/versions/latest/sdk/local-authentication/#securitylevel
+      const securityLevel = await getEnrolledLevelAsync()
+      this.#useAuthentication = securityLevel >= 1; // device has pin or biometrics
+      console.info(`WalletManager.initialize] Device Security Level: ${securityLevel} useAuthentication:${this.#useAuthentication}`)
+    } catch (e) {
+      console.error('[WalletManager.initialize] Unable to determine device security state')
+    }
   }
 
   public get size(): number {
@@ -38,53 +60,43 @@ export class WalletManager {
   }
 
   public async list() {
-    const list: Array<StoredWallet> = []
-    for (const id of this.#index) {
-      try {
-        const w = await this.get(id)
-        if (w) {
-          list.push({ id: w.id, label: w.label, createdAt: w.createdAt })
-        }
-      } catch (e) {
-        console.error('[WalletManager.list] Error getting a wallet')
-      }
-    }
-
-    return list
+    return [...this.#index.values()]
   }
 
   public async add(value: { label: string; mnemonic: string }) {
-    const ids = [...this.#index].sort((a, b) => Number(a) - Number(b))
+    const ids = [...this.#index.keys()].sort((a, b) => Number(a) - Number(b))
     const nextId = ids.length ? String((Number(ids[ids.length - 1]) || 0) + 1) : '1'
-
-    return this.set(nextId, { ...value, id: nextId, createdAt: Date.now() })
+    const wallet = await this.#setMnemonic(nextId, { ...value, id: nextId, createdAt: Date.now() })
+    if (wallet) {
+      try {
+        const storedWallet = this.setStoredWallet(nextId, wallet.storedWallet)
+        // Verify save and add to index
+        await this.#updateIndex(nextId, UpdateAction.ADD, wallet)
+        return storedWallet;
+      } catch (e) {
+        // if we fail here we should make sure to clean up
+        this.deleteWallet(nextId);
+      }
+    }
   }
 
-  public async delete(key: string): Promise<boolean> {
+  public async deleteWallet(key: string): Promise<boolean> {
     try {
+      await deleteItemAsync(getMnemonicKey(key))
+    } catch (e) {
+      console.error('[WalletManager.delete] Error deleting a wallet mnemonic')
+    }
+
+    try {
+      await AsyncStorage.removeItem(getWalletKey(key))
       await this.#updateIndex(key, UpdateAction.REMOVE)
       return true
     } catch (e) {
       console.error('[WalletManager.delete] Error deleting a wallet')
     }
-
     return false
   }
 
-  public async get(key: string) {
-    if (this.has(key)) {
-      try {
-        const result = await getItemAsync(getKey(key))
-        if (result) return Wallet.fromJSON(result).toJSON()
-      } catch (e) {
-        // Delete a saved wallet if it's not valid
-        await this.delete(key)
-        console.error('[WalletManager.get] Unable to get mnemonic', e)
-      }
-    }
-
-    return null
-  }
 
   public has(key: string): boolean {
     return this.#index.has(key)
@@ -94,12 +106,18 @@ export class WalletManager {
     return this.#index.keys()
   }
 
-  public async update(key: string, value: Partial<StoredWalletWithMnemonic>) {
+  public async updateStoredWallet(key: string, value: Partial<StoredWalletWithMnemonic>) {
     try {
-      const originalWallet = await this.get(key)
+      const originalWallet = await this.#getStoredWallet(key)
       if (originalWallet) {
-        return this.set(key, { ...originalWallet, label: value.label ?? originalWallet.label })
+        console.log("update wallet", { ...originalWallet, label: value.label ?? originalWallet.label })
+        const storedWallet = await this.setStoredWallet(key, { ...originalWallet, label: value.label ?? originalWallet.label })
+        if (storedWallet) {
+          await this.#updateIndex(key, UpdateAction.ADD, storedWallet);
+          return storedWallet;
+        }
       }
+      console.error('[update] Unable to find wallet to updated')
     } catch (e) {
       console.error('[update] Unable to update wallet', e)
     }
@@ -107,49 +125,122 @@ export class WalletManager {
     return null
   }
 
-  public async set(key: string, value: StoredWalletWithMnemonic, requireAuthentication: boolean = true): Promise<StoredWallet | null> {
+  public async getStoredWalletWithMnemonic(key: string) {
+    const keyString = key.toString();
+    const storedWallet = await this.#getStoredWallet(keyString);
+    const mnemonic = await this.#getMnemonic(keyString);
+    if (storedWallet && mnemonic) {
+      return (new Wallet({ ...storedWallet, mnemonic })).toJSON()
+    }
+  }
+
+
+  public async setStoredWallet(key: string, value: StoredWallet): Promise<StoredWallet | null> {
+    if (!isValidStoredWallet(value)) {
+      console.error(`[setStoredWallet] Attempt to set failed: Invalid Stored Wallet`)
+      return null
+    }
+
     try {
-      const wallet = new Wallet(value)
-      await setItemAsync(getKey(key), JSON.stringify(wallet.toJSON()), {
-        keychainAccessible: WHEN_UNLOCKED,
-        requireAuthentication
-      })
-      // Verify save and add to index
-      await this.#updateIndex(key, UpdateAction.ADD)
-      return { id: wallet.id, label: wallet.label, createdAt: wallet.createdAt }
+      await AsyncStorage.setItem(getWalletKey(key), JSON.stringify({ ...value }))
+      return { id: value.id, label: value.label, createdAt: value.createdAt }
     } catch (e) {
-      console.error('[setMnemonic] Unable to set mnemonic', e)
+      console.error(`[setStoredWallet] Unable to set: ${e}`)
       return null
     }
   }
 
-  async #updateIndex(key: string, action: UpdateAction) {
+
+  async #getStoredWallet(key: string) {
+    if (this.has(key)) {
+      try {
+        const result = await AsyncStorage.getItem(getWalletKey(key));
+        if (result) {
+          const storedWallet: StoredWallet = JSON.parse(result)
+          if (isValidStoredWallet(storedWallet)) {
+            return storedWallet
+          } else {
+            console.error('[WalletManager.getStoredWallet] Is not valid stored wallet:', storedWallet, typeof storedWallet, isValidDeviceId(storedWallet.id), Boolean(storedWallet.label))
+          }
+        }
+        return null
+      } catch (e) {
+        // Delete a saved wallet if it's not valid
+        await this.deleteWallet(key)
+        console.error('[WalletManager.getStoredWallet] Unable to get stored wallet', e)
+      }
+    }
+    console.error('[WalletManager.getStoredWallet] Key not found:', key)
+    return null
+  }
+
+  async #getMnemonic(key: string) {
+    if (this.has(key)) {
+      try {
+        const result = await getItemAsync(getMnemonicKey(key))
+        if (result) {
+          const storedMnemonic: StoredMnemonic = JSON.parse(result)
+          return parseMnemonic(storedMnemonic.mnemonic)
+        }
+      } catch (e) {
+        // Delete if it's not valid
+        await this.deleteWallet(key)
+        console.error('[WalletManager.getMnemonic] Unable to get mnemonic', e)
+      }
+    }
+    return null
+  }
+
+  async #updateIndex(key: string, action: UpdateAction.REMOVE): Promise<void>
+  async #updateIndex(key: string, action: UpdateAction.ADD, wallet: StoredWallet): Promise<void>
+  async #updateIndex(key: string, action: UpdateAction, wallet?: StoredWallet): Promise<void> {
     console.log('[#updateIndex] Index Before', [...this.#index])
     try {
       // If we're adding a new deviceId, add it to the list to check
-      if (action === UpdateAction.ADD) {
-        this.#index.add(key)
+      if (action === UpdateAction.ADD && wallet && wallet.id === key) {
+        this.#index.set(key, wallet)
       }
 
-      for (const id of this.#index) {
-        const exists = await getItemAsync(getKey(id))
-        // Use a key of '*' to delete all wallets
-        if (!exists || (action === UpdateAction.REMOVE && (key === id || key === '*'))) {
-          try {
-            // This is the only place we remove an item from the index
-            await deleteItemAsync(getKey(id))
-            this.#index.delete(id)
-            console.log('[#updateIndex] Removed item', id)
-          } catch (e) {
-            console.error('[#updateIndex] Could not remove invalid mnemonic', id, e)
-          }
-        }
+      if (action === UpdateAction.REMOVE) {
+        this.#index.delete(key)
       }
-      await setItemAsync('mnemonic-index', JSON.stringify([...this.#index]), { requireAuthentication: false});
+
+      // We can't verify each saved mnemonic anymore because it'll prompt for biometrics
+      await AsyncStorage.setItem('mnemonic-index', JSON.stringify([...this.#index]))
       console.log('[#updateIndex] Index After', [...this.#index])
     } catch (e) {
       console.error('[#updateIndex] Error updating mnemonic index', e)
       throw e
+    }
+  }
+
+
+  async #setMnemonic(key: string, value: StoredWalletWithMnemonic): Promise<Wallet | null> {
+    try {
+      const wallet = new Wallet(value)
+      try {
+        await setItemAsync(getMnemonicKey(key), JSON.stringify({ mnemonic: wallet.toJSON().mnemonic }), {
+          keychainAccessible: WHEN_UNLOCKED,
+          requireAuthentication: this.#useAuthentication
+        })
+      } catch (e) {
+        console.error(`[setMnemonic] Attempt to set mnemonic failed: ${e} requireAuthentication:${this.#useAuthentication}`)
+        // if we attempted with auth, fallback to attempt without auth.  This may be only an issue on the emulators, but just in case
+        // this may be better than failing entirely and having the app not work. 
+        try {
+          await setItemAsync(getMnemonicKey(key), JSON.stringify({ mnemonic: wallet.toJSON().mnemonic }), {
+            keychainAccessible: WHEN_UNLOCKED,
+            requireAuthentication: false,
+          })
+        } catch (e) {
+          console.error(`[setMnemonic] Unable to set mnemonic: ${e}`)
+          return null
+        }
+      }
+      return wallet;
+    } catch (e) {
+      console.error(`[setMnemonic] Attempt to set failed: ${e} requireAuthentication:${this.#useAuthentication}`)
+      return null
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5656,6 +5656,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-local-authentication@npm:^12.3.0":
+  version: 12.3.0
+  resolution: "expo-local-authentication@npm:12.3.0"
+  dependencies:
+    "@expo/config-plugins": ~5.0.0
+    invariant: ^2.2.4
+  peerDependencies:
+    expo: "*"
+  checksum: 09b2f9d9fa98bb96c6b78a46d2e0249abe6a57cfa9d74fff594b7d344dce923820990d4df8d0cbe4b7861bbb05b476aa5fc8accd6bf220c73645b7937328eef9
+  languageName: node
+  linkType: hard
+
 "expo-modules-autolinking@npm:0.10.3, expo-modules-autolinking@npm:^0.10.3":
   version: 0.10.3
   resolution: "expo-modules-autolinking@npm:0.10.3"
@@ -11073,6 +11085,7 @@ __metadata:
     eslint-plugin-react: ^7.31.8
     eslint-plugin-react-native: ^4.0.0
     expo: ^46.0.10
+    expo-local-authentication: ^12.3.0
     expo-modules-autolinking: ^0.10.3
     expo-modules-core: ^0.11.5
     expo-secure-store: ^11.3.0


### PR DESCRIPTION
From discord:

With the delay there I started look at getting biometrics into the app.  I discovered that if we want to use the authentication that is baked into the secure storage on the devices, it will require that the seeds are saved with that flag on when we push them into the store.  This means that if we wait until later to introduce bio metrics, we will need to write code in order to migrate all of the seeds that a users has that aren't secured with biometrics.

That pushed me to think about if we could get this in prior to to our release, since it theoretically would be less work and less risk to do it now.  I had a POC working for it, but it unearthed a slight complication due to the fact that we are storing the seed meta data (wallet name,etc) in the secure store.  So when a user wants to see all the possible wallets, it would prompt them N times to authenticate.  This means that we needed to seperate the storage of the meta data from the mnemonic, so the meta data can live in non secure storage so the user doesn't have to authenticate to see a list of all wallets.

I have that working in the emulator now, but it was a relatively large change to all of the base wallet logic that we have been testing this whole time.  


# Risks:

1. Indexing between secure and normal storage gets out of sink
2. We are somehow storing a seed in the normal storage


# Other info
This should work on devices with no-pin,pin or biometrics.  It has a fallback for devices that don't support or don't have these features set up.

# Testing 

Mainly around CRUD operations for the wallets

- I have tested this in the emulator fos iOS (note the emulator doesn't simulate the auth correctly, so it uses the fallback)
- I have tested on my device

I have not tested on android or android emulator. 

