### PR TITLE
fix: settings hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ cp .env.template .env
 
 2. Start Metro
 ```
-yarn start
+yarn start # add `--reset-cache` to wipe metro cache (required for .env changes)
 ```
-
 3. Start the app
 ```
 cd ios

--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ cp .env.template .env
 
 2. Start Metro
 ```
-yarn start # add `--reset-cache` to wipe metro cache (required for .env changes)
+yarn start
+# add --reset-cache to wipe metro cache (required for .env changes)
 ```
 3. Start the app
 ```
 cd ios
 pod install
 yarn ios
+# add --device 'iPhone' (replacing iPhone with your device name) to run on device. add --simulator 'iPhone 14' to specify iPhone 14 simulator
 ```
 
 ### Publishing builds on ios

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ yarn start
 cd ios
 pod install
 yarn ios
-# add --device 'iPhone' (replacing iPhone with your device name) to run on device. add --simulator 'iPhone 14' to specify iPhone 14 simulator
+# add --device 'iPhone' (replacing iPhone with your device name) to run on device. add --simulator 'iPhone 14' to specify iPhone 14 simulator. xcode also has these capabilities
 ```
 
 ### Publishing builds on ios

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "3.0.0",
   "private": true,
   "scripts": {
-    "clean": "yarn clean-react-native && rm -rf node_modules/",
-    "clean-react-native": "react-native clean",
+    "clean": "react-native-clean",
+    "clean-ios": "rm -rf ios/build && rm -rf ios/Pods && react-native-clean",
     "android": "react-native run-android --appId 'com.shapeshift.droid_shapeshift' && yarn start",
     "ios": "react-native run-ios",
     "ios:device": "react-native run-ios --device 'iPhone'",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "private": true,
   "scripts": {
     "clean": "react-native-clean",
-    "clean-ios": "rm -rf ios/build && rm -rf ios/Pods && react-native-clean",
+    "clean:ios": "rm -rf ios/build && rm -rf ios/Pods && react-native-clean",
     "android": "react-native run-android --appId 'com.shapeshift.droid_shapeshift' && yarn start",
     "ios": "react-native run-ios",
-    "ios:device": "react-native run-ios --device 'iPhone'",
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -15,7 +15,15 @@ const useSettingsImpl = () => {
             setSettings({ SHAPESHIFT_URI })
             return setItem(JSON.stringify({ SHAPESHIFT_URI }))
           }
-          setSettings(JSON.parse(data))
+          let parsed: Record<string, unknown> | null
+          try {
+            parsed = JSON.parse(data)
+          } catch (e) {
+            console.error('error parsing settings data: ', e)
+            parsed = {}
+          }
+          setSettings({ ...parsed, SHAPESHIFT_URI })
+          return
         })
         .catch(console.error)
   }, [settings, getItem, setItem])


### PR DESCRIPTION
- The useSettings hook was failing to merge SHAPESHIFT_URI with existing settings data when present. This allows changing the SHAPESHIFT_URI after the initial app launch/setup.
- add README docs on resetting metro cache, running on device/specific simulator
- clean up npm scripts