### PR TITLE
Adds deep link configuration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
+        <data android:scheme="shapeshift" />
       </intent-filter>
     </activity>
   </application>

--- a/ios/shapeshift/Info.plist
+++ b/ios/shapeshift/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.shapeshift.shapeshift</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>shapeshift</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
# Android 
`<intent-filter>` Requires the data tag in order to open the app via browser link
https://developer.android.com/training/app-links/deep-linking

# iOS
Needs CFBundleURLSchemes in order to deep link
https://book.hacktricks.xyz/mobile-pentesting/ios-pentesting/ios-custom-uri-handlers-deeplinks-custom-schemes


## These changes are required in order to open the app via a browser link in the following format 
```HTML
<a href="shapeshift://"> Open ShapeShift App </a>
```
