### PR TITLE
feat: whitelist chatwoot

### DIFF
--- a/env.template
+++ b/env.template
@@ -3,4 +3,7 @@ SHAPESHIFT_PRIVATE_URI=https://private.shapeshift.com
 SHAPESHIFT_SANDBOX_URI=https://yeet.shapeshift.com
 DEVELOP_URI=https://develop.shapeshift.com
 RELEASE_URI=https://release.shapeshift.com
+
+# used for support widget, a la intercom
+CHATWOOT_URI=https://app.chatwoot.com
 LOGGING_WEBVIEW=true

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -26,14 +26,14 @@ PODS:
   - EXSplashScreen (0.16.2):
     - ExpoModulesCore
     - React-Core
-  - FBLazyVector (0.70.1)
-  - FBReactNativeSpec (0.70.1):
+  - FBLazyVector (0.70.8)
+  - FBReactNativeSpec (0.70.8):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.70.1)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Core (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
+    - RCTRequired (= 0.70.8)
+    - RCTTypeSafety (= 0.70.8)
+    - React-Core (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - ReactCommon/turbomodule/core (= 0.70.8)
   - Flipper (0.125.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
@@ -117,214 +117,214 @@ PODS:
     - fmt (~> 6.2.1)
     - glog
     - libevent
-  - RCTRequired (0.70.1)
-  - RCTTypeSafety (0.70.1):
-    - FBLazyVector (= 0.70.1)
-    - RCTRequired (= 0.70.1)
-    - React-Core (= 0.70.1)
-  - React (0.70.1):
-    - React-Core (= 0.70.1)
-    - React-Core/DevSupport (= 0.70.1)
-    - React-Core/RCTWebSocket (= 0.70.1)
-    - React-RCTActionSheet (= 0.70.1)
-    - React-RCTAnimation (= 0.70.1)
-    - React-RCTBlob (= 0.70.1)
-    - React-RCTImage (= 0.70.1)
-    - React-RCTLinking (= 0.70.1)
-    - React-RCTNetwork (= 0.70.1)
-    - React-RCTSettings (= 0.70.1)
-    - React-RCTText (= 0.70.1)
-    - React-RCTVibration (= 0.70.1)
-  - React-bridging (0.70.1):
+  - RCTRequired (0.70.8)
+  - RCTTypeSafety (0.70.8):
+    - FBLazyVector (= 0.70.8)
+    - RCTRequired (= 0.70.8)
+    - React-Core (= 0.70.8)
+  - React (0.70.8):
+    - React-Core (= 0.70.8)
+    - React-Core/DevSupport (= 0.70.8)
+    - React-Core/RCTWebSocket (= 0.70.8)
+    - React-RCTActionSheet (= 0.70.8)
+    - React-RCTAnimation (= 0.70.8)
+    - React-RCTBlob (= 0.70.8)
+    - React-RCTImage (= 0.70.8)
+    - React-RCTLinking (= 0.70.8)
+    - React-RCTNetwork (= 0.70.8)
+    - React-RCTSettings (= 0.70.8)
+    - React-RCTText (= 0.70.8)
+    - React-RCTVibration (= 0.70.8)
+  - React-bridging (0.70.8):
     - RCT-Folly (= 2021.07.22.00)
-    - React-jsi (= 0.70.1)
-  - React-callinvoker (0.70.1)
-  - React-Codegen (0.70.1):
-    - FBReactNativeSpec (= 0.70.1)
+    - React-jsi (= 0.70.8)
+  - React-callinvoker (0.70.8)
+  - React-Codegen (0.70.8):
+    - FBReactNativeSpec (= 0.70.8)
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.70.1)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Core (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-Core (0.70.1):
+    - RCTRequired (= 0.70.8)
+    - RCTTypeSafety (= 0.70.8)
+    - React-Core (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - ReactCommon/turbomodule/core (= 0.70.8)
+  - React-Core (0.70.8):
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.70.1)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-Core/Default (= 0.70.8)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.70.1):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-    - Yoga
-  - React-Core/Default (0.70.1):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-    - Yoga
-  - React-Core/DevSupport (0.70.1):
-    - glog
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.70.1)
-    - React-Core/RCTWebSocket (= 0.70.1)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-jsinspector (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.70.1):
+  - React-Core/CoreModulesHeaders (0.70.8):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.70.1):
+  - React-Core/Default (0.70.8):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
+    - Yoga
+  - React-Core/DevSupport (0.70.8):
+    - glog
+    - RCT-Folly (= 2021.07.22.00)
+    - React-Core/Default (= 0.70.8)
+    - React-Core/RCTWebSocket (= 0.70.8)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-jsinspector (= 0.70.8)
+    - React-perflogger (= 0.70.8)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.70.8):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.70.1):
+  - React-Core/RCTAnimationHeaders (0.70.8):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
     - Yoga
-  - React-Core/RCTImageHeaders (0.70.1):
+  - React-Core/RCTBlobHeaders (0.70.8):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.70.1):
+  - React-Core/RCTImageHeaders (0.70.8):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.70.1):
+  - React-Core/RCTLinkingHeaders (0.70.8):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.70.1):
+  - React-Core/RCTNetworkHeaders (0.70.8):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
     - Yoga
-  - React-Core/RCTTextHeaders (0.70.1):
+  - React-Core/RCTSettingsHeaders (0.70.8):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.70.1):
+  - React-Core/RCTTextHeaders (0.70.8):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
     - Yoga
-  - React-Core/RCTWebSocket (0.70.1):
+  - React-Core/RCTVibrationHeaders (0.70.8):
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.70.1)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-Core/Default
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
     - Yoga
-  - React-CoreModules (0.70.1):
+  - React-Core/RCTWebSocket (0.70.8):
+    - glog
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Codegen (= 0.70.1)
-    - React-Core/CoreModulesHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-RCTImage (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-cxxreact (0.70.1):
+    - React-Core/Default (= 0.70.8)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-perflogger (= 0.70.8)
+    - Yoga
+  - React-CoreModules (0.70.8):
+    - RCT-Folly (= 2021.07.22.00)
+    - RCTTypeSafety (= 0.70.8)
+    - React-Codegen (= 0.70.8)
+    - React-Core/CoreModulesHeaders (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-RCTImage (= 0.70.8)
+    - ReactCommon/turbomodule/core (= 0.70.8)
+  - React-cxxreact (0.70.8):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsinspector (= 0.70.1)
-    - React-logger (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-    - React-runtimeexecutor (= 0.70.1)
-  - React-hermes (0.70.1):
+    - React-callinvoker (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsinspector (= 0.70.8)
+    - React-logger (= 0.70.8)
+    - React-perflogger (= 0.70.8)
+    - React-runtimeexecutor (= 0.70.8)
+  - React-hermes (0.70.8):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - RCT-Folly/Futures (= 2021.07.22.00)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-jsiexecutor (= 0.70.1)
-    - React-jsinspector (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-  - React-jsi (0.70.1):
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-jsiexecutor (= 0.70.8)
+    - React-jsinspector (= 0.70.8)
+    - React-perflogger (= 0.70.8)
+  - React-jsi (0.70.8):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-jsi/Default (= 0.70.1)
-  - React-jsi/Default (0.70.1):
+    - React-jsi/Default (= 0.70.8)
+  - React-jsi/Default (0.70.8):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-  - React-jsiexecutor (0.70.1):
+  - React-jsiexecutor (0.70.8):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-perflogger (= 0.70.1)
-  - React-jsinspector (0.70.1)
-  - React-logger (0.70.1):
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-perflogger (= 0.70.8)
+  - React-jsinspector (0.70.8)
+  - React-logger (0.70.8):
     - glog
   - react-native-shake (5.1.1):
     - React
@@ -332,72 +332,72 @@ PODS:
     - React
   - react-native-webview (11.23.1):
     - React-Core
-  - React-perflogger (0.70.1)
-  - React-RCTActionSheet (0.70.1):
-    - React-Core/RCTActionSheetHeaders (= 0.70.1)
-  - React-RCTAnimation (0.70.1):
+  - React-perflogger (0.70.8)
+  - React-RCTActionSheet (0.70.8):
+    - React-Core/RCTActionSheetHeaders (= 0.70.8)
+  - React-RCTAnimation (0.70.8):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTAnimationHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTBlob (0.70.1):
+    - RCTTypeSafety (= 0.70.8)
+    - React-Codegen (= 0.70.8)
+    - React-Core/RCTAnimationHeaders (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - ReactCommon/turbomodule/core (= 0.70.8)
+  - React-RCTBlob (0.70.8):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTBlobHeaders (= 0.70.1)
-    - React-Core/RCTWebSocket (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-RCTNetwork (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTImage (0.70.1):
+    - React-Codegen (= 0.70.8)
+    - React-Core/RCTBlobHeaders (= 0.70.8)
+    - React-Core/RCTWebSocket (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-RCTNetwork (= 0.70.8)
+    - ReactCommon/turbomodule/core (= 0.70.8)
+  - React-RCTImage (0.70.8):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTImageHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-RCTNetwork (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTLinking (0.70.1):
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTLinkingHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTNetwork (0.70.1):
+    - RCTTypeSafety (= 0.70.8)
+    - React-Codegen (= 0.70.8)
+    - React-Core/RCTImageHeaders (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-RCTNetwork (= 0.70.8)
+    - ReactCommon/turbomodule/core (= 0.70.8)
+  - React-RCTLinking (0.70.8):
+    - React-Codegen (= 0.70.8)
+    - React-Core/RCTLinkingHeaders (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - ReactCommon/turbomodule/core (= 0.70.8)
+  - React-RCTNetwork (0.70.8):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTNetworkHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTSettings (0.70.1):
+    - RCTTypeSafety (= 0.70.8)
+    - React-Codegen (= 0.70.8)
+    - React-Core/RCTNetworkHeaders (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - ReactCommon/turbomodule/core (= 0.70.8)
+  - React-RCTSettings (0.70.8):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.70.1)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTSettingsHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-RCTText (0.70.1):
-    - React-Core/RCTTextHeaders (= 0.70.1)
-  - React-RCTVibration (0.70.1):
+    - RCTTypeSafety (= 0.70.8)
+    - React-Codegen (= 0.70.8)
+    - React-Core/RCTSettingsHeaders (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - ReactCommon/turbomodule/core (= 0.70.8)
+  - React-RCTText (0.70.8):
+    - React-Core/RCTTextHeaders (= 0.70.8)
+  - React-RCTVibration (0.70.8):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.70.1)
-    - React-Core/RCTVibrationHeaders (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - ReactCommon/turbomodule/core (= 0.70.1)
-  - React-runtimeexecutor (0.70.1):
-    - React-jsi (= 0.70.1)
-  - ReactCommon/turbomodule/core (0.70.1):
+    - React-Codegen (= 0.70.8)
+    - React-Core/RCTVibrationHeaders (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - ReactCommon/turbomodule/core (= 0.70.8)
+  - React-runtimeexecutor (0.70.8):
+    - React-jsi (= 0.70.8)
+  - ReactCommon/turbomodule/core (0.70.8):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.07.22.00)
-    - React-bridging (= 0.70.1)
-    - React-callinvoker (= 0.70.1)
-    - React-Core (= 0.70.1)
-    - React-cxxreact (= 0.70.1)
-    - React-jsi (= 0.70.1)
-    - React-logger (= 0.70.1)
-    - React-perflogger (= 0.70.1)
+    - React-bridging (= 0.70.8)
+    - React-callinvoker (= 0.70.8)
+    - React-Core (= 0.70.8)
+    - React-cxxreact (= 0.70.8)
+    - React-jsi (= 0.70.8)
+    - React-logger (= 0.70.8)
+    - React-perflogger (= 0.70.8)
   - RNCAsyncStorage (1.17.10):
     - React-Core
   - RNCClipboard (1.11.1):
@@ -629,8 +629,8 @@ SPEC CHECKSUMS:
   ExpoModulesCore: 5a973701f4400d70254bc836305228731c829010
   EXSecureStore: ac4b3c89dd5810528074d9422d5fed5a9e684467
   EXSplashScreen: 799bece80089219b2c989c1082d70f3b00995cda
-  FBLazyVector: d3cdc05875c89782840d2f38e1d6174fab24e4d2
-  FBReactNativeSpec: 0612c8f2dbd774414bb778247c6ec6cb05aa4c50
+  FBLazyVector: ce6c993e675c5e9684e3b83aa0c346eb116c3ec6
+  FBReactNativeSpec: d8772db98ada3c2daf8f65e2105ada77bf209c02
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -646,43 +646,43 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
-  RCTRequired: 1b4e0388c8ad776b2d23f8135926fa4e7ddacdf4
-  RCTTypeSafety: 23dc09d6e9ed210fabab031a568bb0194d492385
-  React: 8ca78b2619353c251478892f087d007365af8170
-  React-bridging: e98ade701d1e8e8e764a5e7a66f1725135a0a8ce
-  React-callinvoker: d32c4a1e448799506e9c45ef25ae8ff3c5f77246
-  React-Codegen: 642c7cc5e5bd43ef07f275da308d86ff05c0069c
-  React-Core: 59487b5839f3ff353bbc847df22fc7f8a42ff421
-  React-CoreModules: 62df56334be6c6ef93e1b637284abb782a731318
-  React-cxxreact: 5a641acd449213f420ec01f0c912c8433a91c4ba
-  React-hermes: 909477fce9db1d83e854489d5f3c360dd40cf8b9
-  React-jsi: 28343c93479aa1380251c450a76a9d6eabacf3cd
-  React-jsiexecutor: 47201924064085223b63ec7e3ee9fd40ad8508e8
-  React-jsinspector: 1363be638eccfe1aea1b10dd42e632b0397e5ec8
-  React-logger: 7bd569e3857d74ed412ce0a5c51f421ff7d4ca7f
+  RCTRequired: 35a7977a5a3cb2d3830c3fef7352b7b116115829
+  RCTTypeSafety: 259790fb8b16c94e57e0d3d1e2479e69a2b93f50
+  React: 89f0551b8f7a555e38ce016a81c50bc68f1972a8
+  React-bridging: 2e425b6bc8536206918fa55bf9dd37016f99bb33
+  React-callinvoker: 1c733126b1e4d95d0d412d95c51cedf06b3b979d
+  React-Codegen: 41d2ddcd966eac2a5f2698d5cd21e3d741e999bd
+  React-Core: 3021f04b6b1a2064952e166470a58db671ed65b1
+  React-CoreModules: f569f295874d0864bfd7a686dad3f828f4e8813a
+  React-cxxreact: a6c952ae24061777510f7e60b808b673e624009e
+  React-hermes: be32d1db90d052cc025a38ec2ea4e1a493d33c6a
+  React-jsi: 3d7bafe69dddd780fb3527b7f939dfcbfd6790b5
+  React-jsiexecutor: bc8556d76f83a1a9075cdee207aad7c0b7b30a33
+  React-jsinspector: 5e5497c844f2381e8648ec3a7d0ad25b3f27f23e
+  React-logger: b277ad8f4473f2506fb30b762b6348534a3de10e
   react-native-shake: 67d43d6af4abfc299400b17fea7d2ec0754c72ac
   react-native-simple-crypto: 499ddd9f317932677e50393e58e7a72bca2a86e1
   react-native-webview: d33e2db8925d090871ffeb232dfa50cb3a727581
-  React-perflogger: 48c6b363e867d64b682e84f80ca45636bd65e19c
-  React-RCTActionSheet: 33c74fe5c754835e3715c300618da9aa2f7203fa
-  React-RCTAnimation: 2dbf0120d4d1ab7716079b4180f2ca89c465e46b
-  React-RCTBlob: ccf17363f809c5030746fdb56641527e6bf9adb7
-  React-RCTImage: 88a61b23cd5a6feb8d4436f1e306d9f2ecee3462
-  React-RCTLinking: c63a07ce60a6cb7642acebc80a447fb3f1872eba
-  React-RCTNetwork: f79b6e7c64e7317d34dec7dcfabd1279a6c1d2e7
-  React-RCTSettings: 1ff0f34d41646c7942adea36ab5706320e693756
-  React-RCTText: 7cb05abb91cae0ab7841d551e811ccefa3714dbd
-  React-RCTVibration: e9164827303fb6a5cf79e4c4af4846a09956b11f
-  React-runtimeexecutor: a11d0c2e14140baf1e449264ca9168ae9ae6bbd0
-  ReactCommon: 7f86326b92009925c6dcf93f8e825060171c379f
+  React-perflogger: e9249a18e055cae96fdf685bf6145cbea62506c8
+  React-RCTActionSheet: a6d2a544a4605a111ce80fa9319cc870ca3ea778
+  React-RCTAnimation: 21b776b15aa5451a0b5bcb342fd2f346817c1101
+  React-RCTBlob: 95f54d45305b4103b29d8b2c1e705b5c3183239a
+  React-RCTImage: 1b76ab9e3b60313edd85bc3fd3e07c29cec6ab68
+  React-RCTLinking: 7176da2a80f3056152a51587812d6d0c451b1f7b
+  React-RCTNetwork: d36f896304e6ef2998f58cd4199a0239bd312318
+  React-RCTSettings: 004b9a1afb5870f4bcd06521c088e738c1558940
+  React-RCTText: a2606a79fdb52dd2bde0d7fde7726160fa16b70c
+  React-RCTVibration: 19d21a3ed620352180800447771f68a101f196e9
+  React-runtimeexecutor: f795fd426264709901c09432c6ce072f8400147e
+  ReactCommon: c440e7f15075e81eb29802521c58a1f38b1aa903
   RNCAsyncStorage: 0c357f3156fcb16c8589ede67cc036330b6698ca
   RNCClipboard: 2834e1c4af68697089cdd455ee4a4cdd198fa7dd
   RNScrypt: 2dcfcc34960afb8836c947b0510167a18ebb0a5a
   RNSVG: 07037623c36f12e41312730622d5f6b3656227ca
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Yoga: 6c8252e38d65aa387daee699eacf027e055e0b31
+  Yoga: d6133108734e69e8c0becc6ba587294b94829687
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 8c0e8a7691566351795b43bc1404ff0efacd5a0a
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash.memoize": "^4.1.2",
     "lodash.once": "^4.1.1",
     "react": "18.2.0",
-    "react-native": "0.70.1",
+    "react-native": "0.70.8",
     "react-native-dotenv": "^3.4.0",
     "react-native-error-boundary": "^1.1.16",
     "react-native-shake": "^5.1.1",

--- a/src/lib/navigationFilter.ts
+++ b/src/lib/navigationFilter.ts
@@ -6,6 +6,7 @@ import {
   SHAPESHIFT_SANDBOX_URI,
   RELEASE_URI,
   DEVELOP_URI,
+  CHATWOOT_URI,
 } from 'react-native-dotenv'
 
 const openBrowser = async (url: string) => {
@@ -22,7 +23,8 @@ export const shouldLoadFilter = (request: ShouldStartLoadRequest) => {
     request.url.startsWith(DEVELOP_URI) ||
     request.url.startsWith(RELEASE_URI) ||
     request.url.startsWith(SHAPESHIFT_PRIVATE_URI) ||
-    request.url.startsWith(SHAPESHIFT_SANDBOX_URI)
+    request.url.startsWith(SHAPESHIFT_SANDBOX_URI) ||
+    request.url.startsWith(CHATWOOT_URI)
   ) {
     return true
   }

--- a/types/react-native-dotenv.d.ts
+++ b/types/react-native-dotenv.d.ts
@@ -4,5 +4,6 @@ declare module 'react-native-dotenv' {
   export const SHAPESHIFT_SANDBOX_URI: string
   export const RELEASE_URI: string
   export const DEVELOP_URI: string
+  export const CHATWOOT_URI: string
   export const LOGGING_WEBVIEW: 'false' | 'true' | undefined
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2427,28 +2427,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-clean@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@react-native-community/cli-clean@npm:9.0.0"
+"@react-native-community/cli-clean@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "@react-native-community/cli-clean@npm:9.2.1"
   dependencies:
-    "@react-native-community/cli-tools": ^9.0.0
+    "@react-native-community/cli-tools": ^9.2.1
     chalk: ^4.1.2
     execa: ^1.0.0
     prompts: ^2.4.0
-  checksum: f14a50cd8507c29b33ef0419ddfeb48383964a433b4a1b26271b141238563d5128ad99e5712b88f6f24390aac3871b4391a42447bf67f0ce06f1a5e263b49d05
+  checksum: 52286695a7197a3679125bf05e33bbcecd9d116d25ba2960a55888d35a9cecc5b1a6857d8edff7bfa2593e11ad496b823f7a5fae5d838c41556a63abd3d62955
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-config@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@react-native-community/cli-config@npm:9.0.0"
+"@react-native-community/cli-config@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "@react-native-community/cli-config@npm:9.2.1"
   dependencies:
-    "@react-native-community/cli-tools": ^9.0.0
+    "@react-native-community/cli-tools": ^9.2.1
     cosmiconfig: ^5.1.0
     deepmerge: ^3.2.0
     glob: ^7.1.3
     joi: ^17.2.1
-  checksum: bba9f2066e161532afdad659e2c85464161ff2cbb89c0392b3ded5ca95bfb45077bf201785ddd101e177096cdb96adc6bb8a340aa0683f033c77010d4b7ad387
+  checksum: 95a6f8f380677b4ed43bbb6853cf9c889cd5be05a89452cc471e4c873bb0939be698f5685261d99113c439df988e8f6022478302878ca8e682fd963b3488703f
   languageName: node
   linkType: hard
 
@@ -2461,13 +2461,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-doctor@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@react-native-community/cli-doctor@npm:9.0.0"
+"@react-native-community/cli-doctor@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "@react-native-community/cli-doctor@npm:9.3.0"
   dependencies:
-    "@react-native-community/cli-config": ^9.0.0
-    "@react-native-community/cli-platform-ios": ^9.0.0
-    "@react-native-community/cli-tools": ^9.0.0
+    "@react-native-community/cli-config": ^9.2.1
+    "@react-native-community/cli-platform-ios": ^9.3.0
+    "@react-native-community/cli-tools": ^9.2.1
     chalk: ^4.1.2
     command-exists: ^1.2.8
     envinfo: ^7.7.2
@@ -2481,75 +2481,75 @@ __metadata:
     strip-ansi: ^5.2.0
     sudo-prompt: ^9.0.0
     wcwidth: ^1.0.1
-  checksum: 10e54d16256c493b55d90c90e9111426e7bd87f375714170b540a0b948258736ec4d50eb8a910c5364fa5ccc5b43ab45531fd51d90a43a88fc7d46bf89fe720a
+  checksum: 5bea6203f0f83f798ef4d7957f4de8b5fea2469d287c0d71c04cb108a2627893a6a385fc19b79337ad9bdc7ba474c65e23e2496735f9e4b4d5759a51dff71204
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-hermes@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@react-native-community/cli-hermes@npm:9.0.0"
+"@react-native-community/cli-hermes@npm:^9.3.1":
+  version: 9.3.1
+  resolution: "@react-native-community/cli-hermes@npm:9.3.1"
   dependencies:
-    "@react-native-community/cli-platform-android": ^9.0.0
-    "@react-native-community/cli-tools": ^9.0.0
+    "@react-native-community/cli-platform-android": ^9.3.1
+    "@react-native-community/cli-tools": ^9.2.1
     chalk: ^4.1.2
     hermes-profile-transformer: ^0.0.6
     ip: ^1.1.5
-  checksum: 6dcf4a6768701cdee2cc606c99b1dfea542fa3d150bacdcd3a2df4a90cd62d7991cdcfa8200a5ba6aea85608f062365c654814e4014ee6aaa503d0104066cc12
+  checksum: 2e021c64de4dd23d27bdb55cd9480ed52a577d606039de038d64027fa159247c2a8b5e7b5380e92c4b5d136f701d061ff6af059aa30f84e18c2cd848d6e73eb8
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-platform-android@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@react-native-community/cli-platform-android@npm:9.0.0"
+"@react-native-community/cli-platform-android@npm:9.3.1, @react-native-community/cli-platform-android@npm:^9.3.1":
+  version: 9.3.1
+  resolution: "@react-native-community/cli-platform-android@npm:9.3.1"
   dependencies:
-    "@react-native-community/cli-tools": ^9.0.0
+    "@react-native-community/cli-tools": ^9.2.1
     chalk: ^4.1.2
     execa: ^1.0.0
     fs-extra: ^8.1.0
     glob: ^7.1.3
     logkitty: ^0.7.1
     slash: ^3.0.0
-  checksum: c5e6160332f89bd5a813415995c685516e8841e13645861f1ac4ebb77bd9bef0c9546060a2b47a3f1ab970ed7f169c61a40b1ea4ce6bcd1e77482b6a91c84a40
+  checksum: 147b581ce8e42aa3ef18484fd854a0c9931b799e78de11951bde46772520ca5d58da5bc00e86c5b23b0c1d56dc1251bd93dd7dd559aa974194f170fdc5cb578c
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-platform-ios@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@react-native-community/cli-platform-ios@npm:9.0.0"
+"@react-native-community/cli-platform-ios@npm:9.3.0, @react-native-community/cli-platform-ios@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "@react-native-community/cli-platform-ios@npm:9.3.0"
   dependencies:
-    "@react-native-community/cli-tools": ^9.0.0
+    "@react-native-community/cli-tools": ^9.2.1
     chalk: ^4.1.2
     execa: ^1.0.0
     glob: ^7.1.3
     ora: ^5.4.1
-  checksum: 0f6125962f8dfddf13f3e152a5d6b0d68605af54721fd4b888d6be3bacba35ed5e7dff783bb0eafcbedd71879487840b66d6755a0d7285a2409d20f96cdc6ec4
+  checksum: c4bf882af92e8557458de98cd57327845c2cc7045bdd1e6cc2ded5911134ea19d75276de4a1bb609e51096207970bc8ccb8a836a9d87bb692dc3f67b48ebfd24
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-plugin-metro@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@react-native-community/cli-plugin-metro@npm:9.0.0"
+"@react-native-community/cli-plugin-metro@npm:^9.2.1":
+  version: 9.3.3
+  resolution: "@react-native-community/cli-plugin-metro@npm:9.3.3"
   dependencies:
-    "@react-native-community/cli-server-api": ^9.0.0
-    "@react-native-community/cli-tools": ^9.0.0
+    "@react-native-community/cli-server-api": ^9.2.1
+    "@react-native-community/cli-tools": ^9.2.1
     chalk: ^4.1.2
-    metro: ^0.72.1
-    metro-config: ^0.72.1
-    metro-core: ^0.72.1
-    metro-react-native-babel-transformer: ^0.72.1
-    metro-resolver: ^0.72.1
-    metro-runtime: ^0.72.1
+    metro: 0.72.4
+    metro-config: 0.72.4
+    metro-core: 0.72.4
+    metro-react-native-babel-transformer: 0.72.4
+    metro-resolver: 0.72.4
+    metro-runtime: 0.72.4
     readline: ^1.3.0
-  checksum: 30d8af8bc428f7bab94babf4b4c5add43b49a520e0a6fe7bc20618bd76cd6067b147fc2a7946e5e9c9eede2d47d995baaa3db16815a6613ac01069fa56e7f35f
+  checksum: 6d3f5ba9c5d275a2d0cea7182d29fb5dccb6d656dd9d5377b943524a1da187c9ab0b338cd22cc1561482826e490c1cc8c1c723521debd0e2a6688a2de12cfd5f
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-server-api@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@react-native-community/cli-server-api@npm:9.0.0"
+"@react-native-community/cli-server-api@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "@react-native-community/cli-server-api@npm:9.2.1"
   dependencies:
     "@react-native-community/cli-debugger-ui": ^9.0.0
-    "@react-native-community/cli-tools": ^9.0.0
+    "@react-native-community/cli-tools": ^9.2.1
     compression: ^1.7.1
     connect: ^3.6.5
     errorhandler: ^1.5.0
@@ -2557,13 +2557,13 @@ __metadata:
     pretty-format: ^26.6.2
     serve-static: ^1.13.1
     ws: ^7.5.1
-  checksum: dc0c319ebd51c8c430015d171523259ffd72712924f7dea63429bcb20003ad768b9785618f7014992a31bfa2a70601870eb00a551f528a2e0dcec9f8d8de23fc
+  checksum: 0452310b2d499560458249101d9ad75886a1553aab6deec6e84d968d5de95bb206266d6254d2b500b3492d266b99fd5e1e0eafb686142900fba6a272ceb4038a
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-tools@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@react-native-community/cli-tools@npm:9.0.0"
+"@react-native-community/cli-tools@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "@react-native-community/cli-tools@npm:9.2.1"
   dependencies:
     appdirsjs: ^1.2.4
     chalk: ^4.1.2
@@ -2574,32 +2574,32 @@ __metadata:
     ora: ^5.4.1
     semver: ^6.3.0
     shell-quote: ^1.7.3
-  checksum: feb9cfc6664401e2dcb5bad2a51121f8ba1aa0d4ccc825c0344dd1d87bfd1cb8c83fb8ab8e3790297e36a9f027f5f22b7fd1cfead26b97a48fe8eb115785094d
+  checksum: 8f99ec43b5bc7b5f90e32cae5ba10f5d64e4f2ca2dfb0b51ac71aae5215747c0672ed05752def89eb47cbdc41231afc29f450ffdc6151bd06f4bf4584a3f4bea
   languageName: node
   linkType: hard
 
-"@react-native-community/cli-types@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@react-native-community/cli-types@npm:9.0.0"
+"@react-native-community/cli-types@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@react-native-community/cli-types@npm:9.1.0"
   dependencies:
     joi: ^17.2.1
-  checksum: 6cf37e04a31ab5b24afc3b953bee1367953451cc0313fac1608d1fd22690fbfcab754caa92cee25bfe8050f836e0f3bd0aeac72d5a4f7e1d34d4fefc63bb15c2
+  checksum: 4ac2b9ba8f05562a30201595f90e12ce7f28f0eed1f34e30a0a085525227c8862454dabeccb5da5eebc21e2856e365b2241599b7182eb5721ebcdfe631407eac
   languageName: node
   linkType: hard
 
-"@react-native-community/cli@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@react-native-community/cli@npm:9.0.0"
+"@react-native-community/cli@npm:9.3.2":
+  version: 9.3.2
+  resolution: "@react-native-community/cli@npm:9.3.2"
   dependencies:
-    "@react-native-community/cli-clean": ^9.0.0
-    "@react-native-community/cli-config": ^9.0.0
+    "@react-native-community/cli-clean": ^9.2.1
+    "@react-native-community/cli-config": ^9.2.1
     "@react-native-community/cli-debugger-ui": ^9.0.0
-    "@react-native-community/cli-doctor": ^9.0.0
-    "@react-native-community/cli-hermes": ^9.0.0
-    "@react-native-community/cli-plugin-metro": ^9.0.0
-    "@react-native-community/cli-server-api": ^9.0.0
-    "@react-native-community/cli-tools": ^9.0.0
-    "@react-native-community/cli-types": ^9.0.0
+    "@react-native-community/cli-doctor": ^9.3.0
+    "@react-native-community/cli-hermes": ^9.3.1
+    "@react-native-community/cli-plugin-metro": ^9.2.1
+    "@react-native-community/cli-server-api": ^9.2.1
+    "@react-native-community/cli-tools": ^9.2.1
+    "@react-native-community/cli-types": ^9.1.0
     chalk: ^4.1.2
     commander: ^9.4.0
     execa: ^1.0.0
@@ -2610,7 +2610,7 @@ __metadata:
     semver: ^6.3.0
   bin:
     react-native: build/bin.js
-  checksum: ceb09c3923f18e775015b7fe0f6619bcc28d4431dcb2d84b3947c1a6b1ad4fef39eb69e9149cf878d34ccdc00c4b53ad72c6e07a646d38278eceeb788a23cdc9
+  checksum: 474711ebfad0834e34026889004bc823b79817fc50fb9b614e987755b7073e251643d1078884d3b49f195c83b18bc32b0e608c512e3928fb0dec8dd6be42e180
   languageName: node
   linkType: hard
 
@@ -7846,6 +7846,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsc-safe-url@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "jsc-safe-url@npm:0.2.4"
+  checksum: 53b5741ba2c0a54da1722929dc80becb2c6fcc9525124fb6c2aec1a00f48e79afffd26816c278111e7b938e37ace029e33cbb8cdaa4ac1f528a87e58022284af
+  languageName: node
+  linkType: hard
+
 "jscodeshift@npm:^0.13.1":
   version: 0.13.1
   resolution: "jscodeshift@npm:0.13.1"
@@ -8389,74 +8396,74 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-babel-transformer@npm:0.72.1":
-  version: 0.72.1
-  resolution: "metro-babel-transformer@npm:0.72.1"
+"metro-babel-transformer@npm:0.72.3":
+  version: 0.72.3
+  resolution: "metro-babel-transformer@npm:0.72.3"
   dependencies:
     "@babel/core": ^7.14.0
     hermes-parser: 0.8.0
-    metro-source-map: 0.72.1
+    metro-source-map: 0.72.3
     nullthrows: ^1.1.1
-  checksum: fcb3d017fa70a03d48cce99f623fe374d02869f6875b8a6b6b71ef42e9c8124af0cf7d83313dc60124694fd895b216749712ebc7ebfd961ff0bcf440c6adce29
+  checksum: 6bce52a924f1eb84ea2859b65d37ab6f90bd998ac68184680afaa627e4d0a933cd7ddba391bcd9ea9fb8cacd6228615a427342aeeec6e6053600b322990d16f6
   languageName: node
   linkType: hard
 
-"metro-babel-transformer@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-babel-transformer@npm:0.72.2"
+"metro-babel-transformer@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-babel-transformer@npm:0.72.4"
   dependencies:
     "@babel/core": ^7.14.0
     hermes-parser: 0.8.0
-    metro-source-map: 0.72.2
+    metro-source-map: 0.72.4
     nullthrows: ^1.1.1
-  checksum: 0ffd426210846234333c9bf090b58c04744fc796f5468005f3a10e00e60b6b9c159347a5668788099a40b3babcb3db0082527b6952e154319d6821946f13bb11
+  checksum: 15938419a7d689dd77db33db1848009051b3024dac770a72a22092ebac2fcd9ad7fe390f6cb393d0dac2010ee8cb90ffc93d2d16829d478357c5364f6581c893
   languageName: node
   linkType: hard
 
-"metro-cache-key@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-cache-key@npm:0.72.2"
-  checksum: 7f75dbf035156d4a179563568870813d73aced9dc1da8af80023650eb1a0d2c31d45977fe6d5e66ef25eec100c7aab57656d36243ee5e14c0cb34f775b8834b4
+"metro-cache-key@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-cache-key@npm:0.72.4"
+  checksum: 7d2abe03fe2ed737ca4fd5148f7b7e47698fc1d5f8ac553199529a5578cbc461c0f8f6417236fc6c472d89d2575dbdc16f5eea858c70da8cf17b9a50ba841f3e
   languageName: node
   linkType: hard
 
-"metro-cache@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-cache@npm:0.72.2"
+"metro-cache@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-cache@npm:0.72.4"
   dependencies:
-    metro-core: 0.72.2
+    metro-core: 0.72.4
     rimraf: ^2.5.4
-  checksum: 6b38d2df2e7dc1a2a61ee170a25837040f2961bbfe354d976a4b79f78a0053f4b39120ca72c55e739a9d31d4e9a34b8c8d5c955f428bc20290430ab4521b7aff
+  checksum: bde59087e63f0ea9b670dbebcc00edadd7beaec9e1795ffbdf3e223b9ad53858154ccc1c25f9fa7202cd4592b615dae63d2e2982e2e13e66cfcfc573cfe6f68c
   languageName: node
   linkType: hard
 
-"metro-config@npm:0.72.2, metro-config@npm:^0.72.1":
-  version: 0.72.2
-  resolution: "metro-config@npm:0.72.2"
+"metro-config@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-config@npm:0.72.4"
   dependencies:
     cosmiconfig: ^5.0.5
     jest-validate: ^26.5.2
-    metro: 0.72.2
-    metro-cache: 0.72.2
-    metro-core: 0.72.2
-    metro-runtime: 0.72.2
-  checksum: 48a0b9ceb374348867e335c84bb30de6b59d167a74c52d317f8bdc50426738adf290794df4f787a0726675a3871ae4edc3c2211a4d7b6ec9d939b0bda836cbcf
+    metro: 0.72.4
+    metro-cache: 0.72.4
+    metro-core: 0.72.4
+    metro-runtime: 0.72.4
+  checksum: ed9f69b8fb781e3bd048b98ea5136d86117b54f7689b607911002937f792a93e7aed03e8eabdea1b2a6c595113e85f67ebec46888f38a526cc95d85c0e30a0b1
   languageName: node
   linkType: hard
 
-"metro-core@npm:0.72.2, metro-core@npm:^0.72.1":
-  version: 0.72.2
-  resolution: "metro-core@npm:0.72.2"
+"metro-core@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-core@npm:0.72.4"
   dependencies:
     lodash.throttle: ^4.1.1
-    metro-resolver: 0.72.2
-  checksum: 909eae830fd4bb9c2cd4cfb8d2606a93899d9c6b9275d1693110b74eaf4129c356cdef28bf1b4a58a39049e87b83a18b5df49143ddae58da504c7154d30b6109
+    metro-resolver: 0.72.4
+  checksum: ab8318a67fc51285f0ac147a2935b79dae446cad24233e54560a1a8f6df47e9b134ef6d62f7965fe30680740cb402b5ba9b2a6301ab9552390bf9680b65aa294
   languageName: node
   linkType: hard
 
-"metro-file-map@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-file-map@npm:0.72.2"
+"metro-file-map@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-file-map@npm:0.72.4"
   dependencies:
     abort-controller: ^3.0.0
     anymatch: ^3.0.3
@@ -8474,20 +8481,20 @@ __metadata:
   dependenciesMeta:
     fsevents:
       optional: true
-  checksum: bb6a349e73fc81e169e7f6e50ad0d89d175513cebd7959231f5935416b5f341c0fa1bd4989dddea7f6ce54b36e1992e1f4884f7695504ac0cbac53f7912b2ec9
+  checksum: 6fce50129fa357cbd179f000128d2cd3b17de1af24aa0ba07b9fba3b9c9976b490749851c0c70db6ecbabb76a5da978dd99189cdd452b7acd6f8f1b286020677
   languageName: node
   linkType: hard
 
-"metro-hermes-compiler@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-hermes-compiler@npm:0.72.2"
-  checksum: 885fbba33e6fb49cfd149a842999796a76bd4b9081b77e0e2933888a8018ad5ecac4083a5fff786c44b73c005586de43d19c7f42a71d2155545aff5fd51a6562
+"metro-hermes-compiler@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-hermes-compiler@npm:0.72.4"
+  checksum: 8510f8c768713b115aaff0501ca9d7fb6d4dcf76c12775c8e615c3b88e8f0e0ab9ba165bcf1cff9f40ea1ce8c8368a0e1c5a39a674feb0f864e461ba842dac43
   languageName: node
   linkType: hard
 
-"metro-inspector-proxy@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-inspector-proxy@npm:0.72.2"
+"metro-inspector-proxy@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-inspector-proxy@npm:0.72.4"
   dependencies:
     connect: ^3.6.5
     debug: ^2.2.0
@@ -8495,118 +8502,20 @@ __metadata:
     yargs: ^15.3.1
   bin:
     metro-inspector-proxy: src/cli.js
-  checksum: 678065f511a30bcd244d0e503fc42294f99679c5a32864a6d6ab750745918002061cd3685d93448225ada58cc5454e36ea96d69a6e35c24273560aae2355b184
+  checksum: 4ae878ff56c647ce32336e8dcdee7e7dc20f7e15d128c93d22873779c93c43767976c4fe02ab23dadf6f66f92ba700a88b35c352a1503d6f6b9eb869881f3b2f
   languageName: node
   linkType: hard
 
-"metro-minify-uglify@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-minify-uglify@npm:0.72.2"
+"metro-minify-uglify@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-minify-uglify@npm:0.72.4"
   dependencies:
     uglify-es: ^3.1.9
-  checksum: fa0a8d5ff7966e6a7320a4d687d30cbda216ec49228ae3e044ab3bb1571e7b52253955970641727cfe284bc1fc66004ce4a1e0bc2535bfcac973058c45f02d1c
+  checksum: d9a8e220d965b08bc2954c43b333bae3b0dcde162a61b649b7906c18169487c621b52591e0fa154877ebfc9f259a98673d34fbbbe64d084ca36b31361c11721a
   languageName: node
   linkType: hard
 
-"metro-react-native-babel-preset@npm:0.72.1":
-  version: 0.72.1
-  resolution: "metro-react-native-babel-preset@npm:0.72.1"
-  dependencies:
-    "@babel/core": ^7.14.0
-    "@babel/plugin-proposal-async-generator-functions": ^7.0.0
-    "@babel/plugin-proposal-class-properties": ^7.0.0
-    "@babel/plugin-proposal-export-default-from": ^7.0.0
-    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.0.0
-    "@babel/plugin-proposal-object-rest-spread": ^7.0.0
-    "@babel/plugin-proposal-optional-catch-binding": ^7.0.0
-    "@babel/plugin-proposal-optional-chaining": ^7.0.0
-    "@babel/plugin-syntax-dynamic-import": ^7.0.0
-    "@babel/plugin-syntax-export-default-from": ^7.0.0
-    "@babel/plugin-syntax-flow": ^7.2.0
-    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.0.0
-    "@babel/plugin-syntax-optional-chaining": ^7.0.0
-    "@babel/plugin-transform-arrow-functions": ^7.0.0
-    "@babel/plugin-transform-async-to-generator": ^7.0.0
-    "@babel/plugin-transform-block-scoping": ^7.0.0
-    "@babel/plugin-transform-classes": ^7.0.0
-    "@babel/plugin-transform-computed-properties": ^7.0.0
-    "@babel/plugin-transform-destructuring": ^7.0.0
-    "@babel/plugin-transform-exponentiation-operator": ^7.0.0
-    "@babel/plugin-transform-flow-strip-types": ^7.0.0
-    "@babel/plugin-transform-function-name": ^7.0.0
-    "@babel/plugin-transform-literals": ^7.0.0
-    "@babel/plugin-transform-modules-commonjs": ^7.0.0
-    "@babel/plugin-transform-named-capturing-groups-regex": ^7.0.0
-    "@babel/plugin-transform-parameters": ^7.0.0
-    "@babel/plugin-transform-react-display-name": ^7.0.0
-    "@babel/plugin-transform-react-jsx": ^7.0.0
-    "@babel/plugin-transform-react-jsx-self": ^7.0.0
-    "@babel/plugin-transform-react-jsx-source": ^7.0.0
-    "@babel/plugin-transform-runtime": ^7.0.0
-    "@babel/plugin-transform-shorthand-properties": ^7.0.0
-    "@babel/plugin-transform-spread": ^7.0.0
-    "@babel/plugin-transform-sticky-regex": ^7.0.0
-    "@babel/plugin-transform-template-literals": ^7.0.0
-    "@babel/plugin-transform-typescript": ^7.5.0
-    "@babel/plugin-transform-unicode-regex": ^7.0.0
-    "@babel/template": ^7.0.0
-    react-refresh: ^0.4.0
-  peerDependencies:
-    "@babel/core": "*"
-  checksum: 4454a939a1f19a228442f882f638f3e087c0d51efbb81c3ac32a21aae5c925b36342d4deeceb672b62a15ac4b175eaa69d44384329912e03ff89368ae0915748
-  languageName: node
-  linkType: hard
-
-"metro-react-native-babel-preset@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-react-native-babel-preset@npm:0.72.2"
-  dependencies:
-    "@babel/core": ^7.14.0
-    "@babel/plugin-proposal-async-generator-functions": ^7.0.0
-    "@babel/plugin-proposal-class-properties": ^7.0.0
-    "@babel/plugin-proposal-export-default-from": ^7.0.0
-    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.0.0
-    "@babel/plugin-proposal-object-rest-spread": ^7.0.0
-    "@babel/plugin-proposal-optional-catch-binding": ^7.0.0
-    "@babel/plugin-proposal-optional-chaining": ^7.0.0
-    "@babel/plugin-syntax-dynamic-import": ^7.0.0
-    "@babel/plugin-syntax-export-default-from": ^7.0.0
-    "@babel/plugin-syntax-flow": ^7.2.0
-    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.0.0
-    "@babel/plugin-syntax-optional-chaining": ^7.0.0
-    "@babel/plugin-transform-arrow-functions": ^7.0.0
-    "@babel/plugin-transform-async-to-generator": ^7.0.0
-    "@babel/plugin-transform-block-scoping": ^7.0.0
-    "@babel/plugin-transform-classes": ^7.0.0
-    "@babel/plugin-transform-computed-properties": ^7.0.0
-    "@babel/plugin-transform-destructuring": ^7.0.0
-    "@babel/plugin-transform-exponentiation-operator": ^7.0.0
-    "@babel/plugin-transform-flow-strip-types": ^7.0.0
-    "@babel/plugin-transform-function-name": ^7.0.0
-    "@babel/plugin-transform-literals": ^7.0.0
-    "@babel/plugin-transform-modules-commonjs": ^7.0.0
-    "@babel/plugin-transform-named-capturing-groups-regex": ^7.0.0
-    "@babel/plugin-transform-parameters": ^7.0.0
-    "@babel/plugin-transform-react-display-name": ^7.0.0
-    "@babel/plugin-transform-react-jsx": ^7.0.0
-    "@babel/plugin-transform-react-jsx-self": ^7.0.0
-    "@babel/plugin-transform-react-jsx-source": ^7.0.0
-    "@babel/plugin-transform-runtime": ^7.0.0
-    "@babel/plugin-transform-shorthand-properties": ^7.0.0
-    "@babel/plugin-transform-spread": ^7.0.0
-    "@babel/plugin-transform-sticky-regex": ^7.0.0
-    "@babel/plugin-transform-template-literals": ^7.0.0
-    "@babel/plugin-transform-typescript": ^7.5.0
-    "@babel/plugin-transform-unicode-regex": ^7.0.0
-    "@babel/template": ^7.0.0
-    react-refresh: ^0.4.0
-  peerDependencies:
-    "@babel/core": "*"
-  checksum: 6acbac43dea0db84cee30c6d3b573cae0b3a323c623a9ee0b242582ec373151d82121271089dd2485a872fe497e0730f3be3f549470809bb312eff130c445c78
-  languageName: node
-  linkType: hard
-
-"metro-react-native-babel-preset@npm:^0.72.3":
+"metro-react-native-babel-preset@npm:0.72.3, metro-react-native-babel-preset@npm:^0.72.3":
   version: 0.72.3
   resolution: "metro-react-native-babel-preset@npm:0.72.3"
   dependencies:
@@ -8652,6 +8561,55 @@ __metadata:
   peerDependencies:
     "@babel/core": "*"
   checksum: 678595fe00c8f9b39517094dc90facc93d514d68b32bc4bb64b7c58b9ab72a36da80b0969da932ef52e4a8d8b223a8ebc731ca0e88e221fb4187db7a4d7e5e79
+  languageName: node
+  linkType: hard
+
+"metro-react-native-babel-preset@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-react-native-babel-preset@npm:0.72.4"
+  dependencies:
+    "@babel/core": ^7.14.0
+    "@babel/plugin-proposal-async-generator-functions": ^7.0.0
+    "@babel/plugin-proposal-class-properties": ^7.0.0
+    "@babel/plugin-proposal-export-default-from": ^7.0.0
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.0.0
+    "@babel/plugin-proposal-object-rest-spread": ^7.0.0
+    "@babel/plugin-proposal-optional-catch-binding": ^7.0.0
+    "@babel/plugin-proposal-optional-chaining": ^7.0.0
+    "@babel/plugin-syntax-dynamic-import": ^7.0.0
+    "@babel/plugin-syntax-export-default-from": ^7.0.0
+    "@babel/plugin-syntax-flow": ^7.2.0
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.0.0
+    "@babel/plugin-syntax-optional-chaining": ^7.0.0
+    "@babel/plugin-transform-arrow-functions": ^7.0.0
+    "@babel/plugin-transform-async-to-generator": ^7.0.0
+    "@babel/plugin-transform-block-scoping": ^7.0.0
+    "@babel/plugin-transform-classes": ^7.0.0
+    "@babel/plugin-transform-computed-properties": ^7.0.0
+    "@babel/plugin-transform-destructuring": ^7.0.0
+    "@babel/plugin-transform-exponentiation-operator": ^7.0.0
+    "@babel/plugin-transform-flow-strip-types": ^7.0.0
+    "@babel/plugin-transform-function-name": ^7.0.0
+    "@babel/plugin-transform-literals": ^7.0.0
+    "@babel/plugin-transform-modules-commonjs": ^7.0.0
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.0.0
+    "@babel/plugin-transform-parameters": ^7.0.0
+    "@babel/plugin-transform-react-display-name": ^7.0.0
+    "@babel/plugin-transform-react-jsx": ^7.0.0
+    "@babel/plugin-transform-react-jsx-self": ^7.0.0
+    "@babel/plugin-transform-react-jsx-source": ^7.0.0
+    "@babel/plugin-transform-runtime": ^7.0.0
+    "@babel/plugin-transform-shorthand-properties": ^7.0.0
+    "@babel/plugin-transform-spread": ^7.0.0
+    "@babel/plugin-transform-sticky-regex": ^7.0.0
+    "@babel/plugin-transform-template-literals": ^7.0.0
+    "@babel/plugin-transform-typescript": ^7.5.0
+    "@babel/plugin-transform-unicode-regex": ^7.0.0
+    "@babel/template": ^7.0.0
+    react-refresh: ^0.4.0
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: eb713f71cb0ed3e6fa7d7efae68f8681a2da8321754185206627b1ebe5d460d1c9fc723ca13e57b682801bf77b59b6e13162da3775e160a62f8e85ace62c3c38
   languageName: node
   linkType: hard
 
@@ -8704,170 +8662,170 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-react-native-babel-transformer@npm:0.72.1":
-  version: 0.72.1
-  resolution: "metro-react-native-babel-transformer@npm:0.72.1"
+"metro-react-native-babel-transformer@npm:0.72.3":
+  version: 0.72.3
+  resolution: "metro-react-native-babel-transformer@npm:0.72.3"
   dependencies:
     "@babel/core": ^7.14.0
     babel-preset-fbjs: ^3.4.0
     hermes-parser: 0.8.0
-    metro-babel-transformer: 0.72.1
-    metro-react-native-babel-preset: 0.72.1
-    metro-source-map: 0.72.1
+    metro-babel-transformer: 0.72.3
+    metro-react-native-babel-preset: 0.72.3
+    metro-source-map: 0.72.3
     nullthrows: ^1.1.1
   peerDependencies:
     "@babel/core": "*"
-  checksum: ed2919f837305e27e6cc7a8b45e21e21c11b71a874a1eae418a7ccd07e900526b0429c92df74710e11befd040ee63446516c0d73568285e76ca0b123f070f7af
+  checksum: e9ae85eb4be2d5e734f3c211f2aee4f655692429775e8fb1a2825faf3920ed00ca96a4506205de193c9de0576d015813636813de9a81ef7c56fe4ce7488e3ed4
   languageName: node
   linkType: hard
 
-"metro-react-native-babel-transformer@npm:^0.72.1":
-  version: 0.72.2
-  resolution: "metro-react-native-babel-transformer@npm:0.72.2"
+"metro-react-native-babel-transformer@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-react-native-babel-transformer@npm:0.72.4"
   dependencies:
     "@babel/core": ^7.14.0
     babel-preset-fbjs: ^3.4.0
     hermes-parser: 0.8.0
-    metro-babel-transformer: 0.72.2
-    metro-react-native-babel-preset: 0.72.2
-    metro-source-map: 0.72.2
+    metro-babel-transformer: 0.72.4
+    metro-react-native-babel-preset: 0.72.4
+    metro-source-map: 0.72.4
     nullthrows: ^1.1.1
   peerDependencies:
     "@babel/core": "*"
-  checksum: 3268e8ac71cc14fbf2eec7cb68d4f3f79d7e9062d27ae2ed00b72de358ef722c2aafa2d808e7c990780792048d51705d7747f4fae76d4e2d7ece1472b75fa430
+  checksum: 235680d4e41d4e12550337580744668e77853cfdce16fcb0fb7f2816a27ef948f1f92cb7f89494f18298ea557bb5b2ba4c9f44e6577d74dec60f276e11d2c3e8
   languageName: node
   linkType: hard
 
-"metro-resolver@npm:0.72.2, metro-resolver@npm:^0.72.1":
-  version: 0.72.2
-  resolution: "metro-resolver@npm:0.72.2"
+"metro-resolver@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-resolver@npm:0.72.4"
   dependencies:
     absolute-path: ^0.0.0
-  checksum: 26ed03645d160df8ac635485065174c7ec323c4a7b2477e47d68363242b317dcdb9fd827fbebabe5efeba49bb236853e9508a642e5d6b9c5e3a75cd6d79af64a
+  checksum: 74ca29ac03717c7054f2b30b2b9cd1599cd7cb0525b813d39492a159c0bed4c7e634a7dcd930b3276dcf82d63146358feeeb6248bf1687a76a8607d0b8e23306
   languageName: node
   linkType: hard
 
-"metro-runtime@npm:0.72.1":
-  version: 0.72.1
-  resolution: "metro-runtime@npm:0.72.1"
+"metro-runtime@npm:0.72.3":
+  version: 0.72.3
+  resolution: "metro-runtime@npm:0.72.3"
   dependencies:
     "@babel/runtime": ^7.0.0
     react-refresh: ^0.4.0
-  checksum: d431eb3e43a529b0c0d96e63e6b24cdc54b723f9ccb5b3a14df57eb75b2242f00f9301ae39d4b1bcac0aa9d6c1341f5ead88d9ce2be2f9dbf571cc04ce1fdc3c
+  checksum: 7017fad668bdf44f1ab57eebd3d6841f7f4f3f5b747970d9e7ec9c4c497ed058c5a153eb41efd598e4bad3f89d036b38e71f3795298b8dbd31ba2a5d974d4019
   languageName: node
   linkType: hard
 
-"metro-runtime@npm:0.72.2, metro-runtime@npm:^0.72.1":
-  version: 0.72.2
-  resolution: "metro-runtime@npm:0.72.2"
+"metro-runtime@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-runtime@npm:0.72.4"
   dependencies:
     "@babel/runtime": ^7.0.0
     react-refresh: ^0.4.0
-  checksum: 7bd6da09df8ceb2ecf831611911e10b35a369c2308574e7c3ac1e8b45540de67dbffd4150c0ce4ad706bb080699a4c9a2df6eb8d9360bc8284cc2cbd88fd9983
+  checksum: ec807aa14e11bddbc8d9a238c7786f679cb0ee602f29f99f7f89dabff496a64d96deaf0b632604e13d46a4651381b6d7dfdacdfa047034253320b8b48a9e49ed
   languageName: node
   linkType: hard
 
-"metro-source-map@npm:0.72.1":
-  version: 0.72.1
-  resolution: "metro-source-map@npm:0.72.1"
+"metro-source-map@npm:0.72.3":
+  version: 0.72.3
+  resolution: "metro-source-map@npm:0.72.3"
   dependencies:
     "@babel/traverse": ^7.14.0
     "@babel/types": ^7.0.0
     invariant: ^2.2.4
-    metro-symbolicate: 0.72.1
+    metro-symbolicate: 0.72.3
     nullthrows: ^1.1.1
-    ob1: 0.72.1
+    ob1: 0.72.3
     source-map: ^0.5.6
     vlq: ^1.0.0
-  checksum: 7720a6f81e2b945b4faef31693e8b0beba705543e6422595261bee226ba092e28d0deef2b7f2efae56d3d1093068d1e2f0cfaf8bf725d7c05590445e06d2f630
+  checksum: 4bbd27097d0de46ed4a091424a3ef497a54f48ae3559751bb619a5a48f637786881ef170c6ef037e8e8581ff3b4f43af5ba44cf9e4bd106c703246e346bb1029
   languageName: node
   linkType: hard
 
-"metro-source-map@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-source-map@npm:0.72.2"
+"metro-source-map@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-source-map@npm:0.72.4"
   dependencies:
     "@babel/traverse": ^7.14.0
     "@babel/types": ^7.0.0
     invariant: ^2.2.4
-    metro-symbolicate: 0.72.2
+    metro-symbolicate: 0.72.4
     nullthrows: ^1.1.1
-    ob1: 0.72.2
+    ob1: 0.72.4
     source-map: ^0.5.6
     vlq: ^1.0.0
-  checksum: 862ffbc342c2971bc46886451db108621df5da0817980e86a2304e5f783706501b65f914ba19d808c6e5c7ec3178dde591e4437d41f64de9ee5c2267ada4dfe5
+  checksum: 5e4b6c6c0b821afea6c5803dfb9fb2abcd5e880f97861bc30bd45b2d8f015f6a1ba968fc2f5f370c990965d434e4deff7b437b8d2edef89345a4d406e61cceaf
   languageName: node
   linkType: hard
 
-"metro-symbolicate@npm:0.72.1":
-  version: 0.72.1
-  resolution: "metro-symbolicate@npm:0.72.1"
+"metro-symbolicate@npm:0.72.3":
+  version: 0.72.3
+  resolution: "metro-symbolicate@npm:0.72.3"
   dependencies:
     invariant: ^2.2.4
-    metro-source-map: 0.72.1
+    metro-source-map: 0.72.3
     nullthrows: ^1.1.1
     source-map: ^0.5.6
     through2: ^2.0.1
     vlq: ^1.0.0
   bin:
     metro-symbolicate: src/index.js
-  checksum: e3fb6d19f3b5e0e36d62ed93c7756bb04a4509810680a89721076e587cbfb01d54d55f92983b782577368b40432469cd8d696ff883122881e6780780feb04543
+  checksum: e2b434d008a086132b999cefa07316f4b9c6e666d169c1a4534085a50046320afd5dd15eeb6849354e82ac360cddb6fa9882ac2da13a70e93bd987675e9d4209
   languageName: node
   linkType: hard
 
-"metro-symbolicate@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-symbolicate@npm:0.72.2"
+"metro-symbolicate@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-symbolicate@npm:0.72.4"
   dependencies:
     invariant: ^2.2.4
-    metro-source-map: 0.72.2
+    metro-source-map: 0.72.4
     nullthrows: ^1.1.1
     source-map: ^0.5.6
     through2: ^2.0.1
     vlq: ^1.0.0
   bin:
     metro-symbolicate: src/index.js
-  checksum: acce83a7b1b25630a57c461081cfe4fe3222ad08ea701fcfa7cdb2734291102dc5a4846e502e87c84406efbcd9b222ea227204855f4dd5525dc16b4804a12f8b
+  checksum: 7fc4be1e426b25af78daceeace1cd8f34cc24035a7a91074183910a719ec20897923b38c2e67fceba5fb0c34cadad50f291d35def8fa630eccb5b658f6868637
   languageName: node
   linkType: hard
 
-"metro-transform-plugins@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-transform-plugins@npm:0.72.2"
+"metro-transform-plugins@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-transform-plugins@npm:0.72.4"
   dependencies:
     "@babel/core": ^7.14.0
     "@babel/generator": ^7.14.0
     "@babel/template": ^7.0.0
     "@babel/traverse": ^7.14.0
     nullthrows: ^1.1.1
-  checksum: 21e4bdeceb705716ec38461a9d3e39b61c16511712b8b61096e00b8468d6f8ebeb587db562d566600cac9fc80658491f764734b960b9ecd6b5e7f74c5072ad90
+  checksum: 484831311f7b0619cbe7fa505f529aae8ffbd4cfa5e6e3929abec702351606d5ba98377862d71c20db4c2d7d0cdfacb3467502c66cd21811252f89ae28d585cf
   languageName: node
   linkType: hard
 
-"metro-transform-worker@npm:0.72.2":
-  version: 0.72.2
-  resolution: "metro-transform-worker@npm:0.72.2"
+"metro-transform-worker@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro-transform-worker@npm:0.72.4"
   dependencies:
     "@babel/core": ^7.14.0
     "@babel/generator": ^7.14.0
     "@babel/parser": ^7.14.0
     "@babel/types": ^7.0.0
     babel-preset-fbjs: ^3.4.0
-    metro: 0.72.2
-    metro-babel-transformer: 0.72.2
-    metro-cache: 0.72.2
-    metro-cache-key: 0.72.2
-    metro-hermes-compiler: 0.72.2
-    metro-source-map: 0.72.2
-    metro-transform-plugins: 0.72.2
+    metro: 0.72.4
+    metro-babel-transformer: 0.72.4
+    metro-cache: 0.72.4
+    metro-cache-key: 0.72.4
+    metro-hermes-compiler: 0.72.4
+    metro-source-map: 0.72.4
+    metro-transform-plugins: 0.72.4
     nullthrows: ^1.1.1
-  checksum: 3f0ae5c92255cd44889767f2c6cf337f1332258cfe99e85ea9874f326f4506b3d4716967433ee131e54628c8a7757bd1190f5df1ae6bf8a1c915fa4140c66c94
+  checksum: 022e3b9b68c61ca3ec08ef5ad0665850903c4c44f6bae885abe28b26bdc4f52a7120767569110b31c65cf3ddef11c3e99605d03c9d83210383b266ab67a866b5
   languageName: node
   linkType: hard
 
-"metro@npm:0.72.2, metro@npm:^0.72.1":
-  version: 0.72.2
-  resolution: "metro@npm:0.72.2"
+"metro@npm:0.72.4":
+  version: 0.72.4
+  resolution: "metro@npm:0.72.4"
   dependencies:
     "@babel/code-frame": ^7.0.0
     "@babel/core": ^7.14.0
@@ -8891,23 +8849,24 @@ __metadata:
     image-size: ^0.6.0
     invariant: ^2.2.4
     jest-worker: ^27.2.0
+    jsc-safe-url: ^0.2.2
     lodash.throttle: ^4.1.1
-    metro-babel-transformer: 0.72.2
-    metro-cache: 0.72.2
-    metro-cache-key: 0.72.2
-    metro-config: 0.72.2
-    metro-core: 0.72.2
-    metro-file-map: 0.72.2
-    metro-hermes-compiler: 0.72.2
-    metro-inspector-proxy: 0.72.2
-    metro-minify-uglify: 0.72.2
-    metro-react-native-babel-preset: 0.72.2
-    metro-resolver: 0.72.2
-    metro-runtime: 0.72.2
-    metro-source-map: 0.72.2
-    metro-symbolicate: 0.72.2
-    metro-transform-plugins: 0.72.2
-    metro-transform-worker: 0.72.2
+    metro-babel-transformer: 0.72.4
+    metro-cache: 0.72.4
+    metro-cache-key: 0.72.4
+    metro-config: 0.72.4
+    metro-core: 0.72.4
+    metro-file-map: 0.72.4
+    metro-hermes-compiler: 0.72.4
+    metro-inspector-proxy: 0.72.4
+    metro-minify-uglify: 0.72.4
+    metro-react-native-babel-preset: 0.72.4
+    metro-resolver: 0.72.4
+    metro-runtime: 0.72.4
+    metro-source-map: 0.72.4
+    metro-symbolicate: 0.72.4
+    metro-transform-plugins: 0.72.4
+    metro-transform-worker: 0.72.4
     mime-types: ^2.1.27
     node-fetch: ^2.2.0
     nullthrows: ^1.1.1
@@ -8921,7 +8880,7 @@ __metadata:
     yargs: ^15.3.1
   bin:
     metro: src/cli.js
-  checksum: de72df21611a71d84b79c938fac92f009983d291f36aacf398cf2bdc58d4aae89afdb0d92d4ea29724ec2e9d80aa5e83c055fc99df0ec51c2f71786eaad37bc2
+  checksum: a92db36211c03da9f8a2bfa31fe401fd66ed1ccd8ce56a013a893abbe83c4313cc4cc1ab81495e9ec719ed2f4768ec74e3a1b6e327b627272a845640ca3894d7
   languageName: node
   linkType: hard
 
@@ -9398,17 +9357,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ob1@npm:0.72.1":
-  version: 0.72.1
-  resolution: "ob1@npm:0.72.1"
-  checksum: 9d00db7bcb3df728689566a667984507a87d6ab8ef6f65adaa52d2895e72196aea78d0b5ccf41aa5e523de33be21ea155dc30b8396773ef748041cd867c1e9e4
+"ob1@npm:0.72.3":
+  version: 0.72.3
+  resolution: "ob1@npm:0.72.3"
+  checksum: 21ef5c2565b3ec0b5f190f117f205548ed3ee935e5884d916da7cb570ad1bd0206e1dbd542b91c004cd4e6eb5ee5100517f37e9664f23dbb6cbecc9cdb5b26eb
   languageName: node
   linkType: hard
 
-"ob1@npm:0.72.2":
-  version: 0.72.2
-  resolution: "ob1@npm:0.72.2"
-  checksum: 0e9f50fc92a6bac544bc315de7c347bb68f0873ec5132890c81797df8343a4b11f4a6970bba60d4c47519239d898f6b9eee9e0f048abac438088827fd2137ead
+"ob1@npm:0.72.4":
+  version: 0.72.4
+  resolution: "ob1@npm:0.72.4"
+  checksum: 81b360262cce0a922d8836b2d2a33e83fbc32517acf0226bd837b80471c4014ded4e16746c3e0397bd1f3c2af880d1bca886505ae445b045c5b0753b4c59638a
   languageName: node
   linkType: hard
 
@@ -10041,12 +10000,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"promise@npm:^8.0.3":
-  version: 8.1.0
-  resolution: "promise@npm:8.1.0"
+"promise@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "promise@npm:8.3.0"
   dependencies:
     asap: ~2.0.6
-  checksum: 89b71a56154ed7d66a73236d8e8351a9c59adddba3929ecc845f75421ff37fc08ea0c67ad76cd5c0b0d81812c7d07a32bed27e7df5fcc960c6d68b0c1cd771f7
+  checksum: a69f0ddbddf78ffc529cffee7ad950d307347615970564b17988ce43fbe767af5c738a9439660b24a9a8cbea106c0dcbb6c2b20e23b7e96a8e89e5c2679e94d5
   languageName: node
   linkType: hard
 
@@ -10191,15 +10150,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-codegen@npm:^0.70.5":
-  version: 0.70.5
-  resolution: "react-native-codegen@npm:0.70.5"
+"react-native-codegen@npm:^0.70.6":
+  version: 0.70.6
+  resolution: "react-native-codegen@npm:0.70.6"
   dependencies:
     "@babel/parser": ^7.14.0
     flow-parser: ^0.121.0
     jscodeshift: ^0.13.1
     nullthrows: ^1.1.1
-  checksum: f02fe72996c0b2fb1f30f87df18c8ba36463058a5c60ac2fceee8b04304ae921f362d683ec27d919b90190ec27e411e926e7ff83e25e7f1d378410dbae577bfa
+  checksum: 2a50ad71e09bc8cbb3694057cf47d6e9665c16f3968d1dc2b71e83c8c4e7be3b07b74bea08750ec9c8f6c60e6c746a5f695963c8694e5a76edcbce35a53a6a06
   languageName: node
   linkType: hard
 
@@ -10287,14 +10246,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native@npm:0.70.1":
-  version: 0.70.1
-  resolution: "react-native@npm:0.70.1"
+"react-native@npm:0.70.8":
+  version: 0.70.8
+  resolution: "react-native@npm:0.70.8"
   dependencies:
     "@jest/create-cache-key-function": ^27.0.1
-    "@react-native-community/cli": ^9.0.0
-    "@react-native-community/cli-platform-android": ^9.0.0
-    "@react-native-community/cli-platform-ios": ^9.0.0
+    "@react-native-community/cli": 9.3.2
+    "@react-native-community/cli-platform-android": 9.3.1
+    "@react-native-community/cli-platform-ios": 9.3.0
     "@react-native/assets": 1.0.0
     "@react-native/normalize-color": 2.0.0
     "@react-native/polyfills": 2.0.0
@@ -10305,15 +10264,15 @@ __metadata:
     invariant: ^2.2.4
     jsc-android: ^250230.2.1
     memoize-one: ^5.0.0
-    metro-react-native-babel-transformer: 0.72.1
-    metro-runtime: 0.72.1
-    metro-source-map: 0.72.1
+    metro-react-native-babel-transformer: 0.72.3
+    metro-runtime: 0.72.3
+    metro-source-map: 0.72.3
     mkdirp: ^0.5.1
     nullthrows: ^1.1.1
     pretty-format: ^26.5.2
-    promise: ^8.0.3
+    promise: ^8.3.0
     react-devtools-core: 4.24.0
-    react-native-codegen: ^0.70.5
+    react-native-codegen: ^0.70.6
     react-native-gradle-plugin: ^0.70.3
     react-refresh: ^0.4.0
     react-shallow-renderer: ^16.15.0
@@ -10327,7 +10286,7 @@ __metadata:
     react: 18.1.0
   bin:
     react-native: cli.js
-  checksum: 766622bb5150269a284c5cfa7f2213a5cc6e1f9637633852da25066f9dfa69b1b459f2152dc2df37e33a1b104b3675c86e1cb0e70419fe2b623fd7089b5cba85
+  checksum: 6cd9d8a187ff71a992c90e49c0be1b0351dce5234d198b2e5999686ab3f1cfc30a2485b3e577329c066943888ee06bc546c3c69f3eae9e721c28280e2eaf12f6
   languageName: node
   linkType: hard
 
@@ -11069,7 +11028,7 @@ __metadata:
     metro-react-native-babel-preset: ^0.72.3
     prettier: ^2.7.1
     react: 18.2.0
-    react-native: 0.70.1
+    react-native: 0.70.8
     react-native-dotenv: ^3.4.0
     react-native-error-boundary: ^1.1.16
     react-native-shake: ^5.1.1


### PR DESCRIPTION
this whitelists the chatwoot url to allow the webview to open it within the app in an iframe

this prevents it from opening in a new tab when the feature flag is enabled in web and allow us to ship this feature for support

to test

1. open simulator/log in with demo wallet
2. click hamburger menu, settings
3. click settings heading 5 times
4. scroll down to debugging section and choose `yeet` as environment (yeet is web `develop` branch with chatwoot feature flag enabled) 
![image](https://github.com/shapeshift/mobile-app/assets/88504456/889f73d5-72f3-4748-a250-ae30b8da8fea)
6. click hamburger menu and click feedback & support, then get support
7. see that chatwoot opens within the app, and doesn't open a new browser tab in safari

![image](https://github.com/shapeshift/mobile-app/assets/88504456/87ff8cfd-5ad6-4a85-84ec-aff6d52db439)

