### PR TITLE
chore: upgrade hermes-engine

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -97,7 +97,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.70.1)
+  - hermes-engine (0.70.8)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -642,7 +642,7 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  hermes-engine: 9cd393f741bfa14d1d0cd90cc373e3619c0bc7ea
+  hermes-engine: 0b19f33a9c2ec1dbdede3232606eeb1101db4cec
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda


### PR DESCRIPTION
this was missed in the previous PR https://github.com/shapeshift/mobile-app/pull/91

this diff in `Podfile.lock` happened after i cleaned my local environment and did a fresh `pod install`

note that the change in versions corresponds to the same `react-native` version changed here https://github.com/shapeshift/mobile-app/pull/91/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L31

## testing steps

1. `cd ios`
2. `pod cache clean --all`
3. `pod install`
4. `git status` - there should be no change to `Podfile.lock`
