### PR TITLE
feat: webview reload handler

### DIFF
--- a/src/lib/getMessageManager.ts
+++ b/src/lib/getMessageManager.ts
@@ -68,5 +68,18 @@ export const getMessageManager = once(() => {
   // clipboard
   messageManager.on('setClipboard', evt => Clipboard.setString(evt.key))
 
+  /**
+   * this handler allows use to do the webview equivalent of window.location.reload()
+   * without this, the web application is unable to reload the webview
+   *
+   * as of writing, this is used in the settings menu of web, with a "clear cache"
+   * button that that blows away the redux persisted cache, then refreshes the page
+   * to get to a good known state by calling this handler
+   */
+  messageManager.on('reloadWebview', () => {
+    console.log('[App] Reloading webview')
+    messageManager.webviewRef?.reload()
+  })
+
   return messageManager
 })


### PR DESCRIPTION
adds a handler to reload the webview when a message is received

this is necessary to be able to clear the cache and get back to a known good state

use this web PR to test

https://github.com/shapeshift/web/pull/4912
