### PR TITLE
feat: add ephemeral environments

### DIFF
--- a/env.template
+++ b/env.template
@@ -1,8 +1,17 @@
+# production environments
 SHAPESHIFT_URI=https://app.shapeshift.com
 SHAPESHIFT_PRIVATE_URI=https://private.shapeshift.com
-SHAPESHIFT_SANDBOX_URI=https://yeet.shapeshift.com
-DEVELOP_URI=https://develop.shapeshift.com
+# release uses production env vars
 RELEASE_URI=https://release.shapeshift.com
+# develop uses dev env vars
+YEET_URI=https://yeet.shapeshift.com
+DEVELOP_URI=https://develop.shapeshift.com
+# ephemeral uses dev env vars
+CAFE_URI=https://cafe.shapeshift.com
+BEARD_URI=https://beard.shapeshift.com
+GOME_URI=https://gome.shapeshift.com
+JUICE_URI=https://juice.shapeshift.com
+WOOD_URI=https://wood.shapeshift.com
 
 # used for support widget, a la intercom
 CHATWOOT_URI=https://app.chatwoot.com

--- a/src/components/DeveloperModeModal.tsx
+++ b/src/components/DeveloperModeModal.tsx
@@ -1,11 +1,16 @@
 import React from 'react'
 import { Alert, Button, FlatList, Modal, Pressable, Text, View } from 'react-native'
 import {
+  BEARD_URI,
+  CAFE_URI,
   DEVELOP_URI,
+  GOME_URI,
+  JUICE_URI,
   RELEASE_URI,
   SHAPESHIFT_PRIVATE_URI,
-  SHAPESHIFT_SANDBOX_URI,
   SHAPESHIFT_URI,
+  WOOD_URI,
+  YEET_URI,
 } from 'react-native-dotenv'
 import { setItemAsync } from 'expo-secure-store'
 import { styles } from '../styles'
@@ -18,40 +23,69 @@ type Environment = {
 }
 
 const ENVIRONMENTS: Environment[] = [
+  /**
+   * production environments
+   */
   {
-    key: 'prod',
-    title: 'Production',
+    key: 'app',
+    title: 'app',
     url: SHAPESHIFT_URI,
   },
   {
     key: 'private',
-    title: 'Production (Private)',
+    title: 'private',
     url: SHAPESHIFT_PRIVATE_URI,
   },
   {
-    key: 'mobile-sandbox',
-    title: 'Mobile Sandbox (yeet)',
-    url: SHAPESHIFT_SANDBOX_URI,
+    key: 'release',
+    title: 'release',
+    url: RELEASE_URI,
   },
+  /**
+   * shared development environments
+   */
   {
     key: 'dev',
-    title: 'Development',
+    title: 'develop',
     url: DEVELOP_URI,
   },
   {
-    key: 'pre-release',
-    title: 'Pre-release',
-    url: RELEASE_URI,
+    key: 'yeet',
+    title: 'yeet',
+    url: YEET_URI,
+  },
+  /**
+   * individual ephemeral environments
+   */
+  {
+    key: 'cafe',
+    title: 'cafe',
+    url: CAFE_URI,
+  },
+  {
+    key: 'beard',
+    title: 'beard',
+    url: BEARD_URI,
+  },
+  {
+    key: 'gome',
+    title: 'gome',
+    url: GOME_URI,
+  },
+  {
+    key: 'juice',
+    title: 'juice',
+    url: JUICE_URI,
+  },
+  {
+    key: 'wood',
+    title: 'wood',
+    url: WOOD_URI,
   },
   {
     key: 'localhost',
-    title: 'Localhost',
+    title: 'localhost',
     url: 'http://localhost:3000',
-  },
-  {
-    key: 'android',
-    title: 'Localhost (Android)',
-    url: 'http://10.0.2.2:3000',
   },
 ]
 

--- a/src/lib/navigationFilter.ts
+++ b/src/lib/navigationFilter.ts
@@ -3,10 +3,15 @@ import { Linking } from 'react-native'
 import {
   SHAPESHIFT_URI,
   SHAPESHIFT_PRIVATE_URI,
-  SHAPESHIFT_SANDBOX_URI,
   RELEASE_URI,
   DEVELOP_URI,
   CHATWOOT_URI,
+  YEET_URI,
+  BEARD_URI,
+  CAFE_URI,
+  GOME_URI,
+  JUICE_URI,
+  WOOD_URI,
 } from 'react-native-dotenv'
 
 const openBrowser = async (url: string) => {
@@ -20,10 +25,15 @@ export const shouldLoadFilter = (request: ShouldStartLoadRequest) => {
   // Navigation within wrapped web app
   if (
     request.url.startsWith(SHAPESHIFT_URI) ||
-    request.url.startsWith(DEVELOP_URI) ||
-    request.url.startsWith(RELEASE_URI) ||
     request.url.startsWith(SHAPESHIFT_PRIVATE_URI) ||
-    request.url.startsWith(SHAPESHIFT_SANDBOX_URI) ||
+    request.url.startsWith(RELEASE_URI) ||
+    request.url.startsWith(DEVELOP_URI) ||
+    request.url.startsWith(YEET_URI) ||
+    request.url.startsWith(BEARD_URI) ||
+    request.url.startsWith(CAFE_URI) ||
+    request.url.startsWith(GOME_URI) ||
+    request.url.startsWith(JUICE_URI) ||
+    request.url.startsWith(WOOD_URI) ||
     request.url.startsWith(CHATWOOT_URI)
   ) {
     return true

--- a/types/react-native-dotenv.d.ts
+++ b/types/react-native-dotenv.d.ts
@@ -1,9 +1,26 @@
 declare module 'react-native-dotenv' {
+  /**
+   * production environments (uses prod env vars)
+   */
   export const SHAPESHIFT_URI: string
   export const SHAPESHIFT_PRIVATE_URI: string
-  export const SHAPESHIFT_SANDBOX_URI: string
   export const RELEASE_URI: string
+  /**
+   * shared development environments
+   */
   export const DEVELOP_URI: string
+  export const YEET_URI: string
+  /**
+   * ephemeral environments (uses develop env vars)
+   */
+  export const CAFE_URI: string
+  export const BEARD_URI: string
+  export const GOME_URI: string
+  export const JUICE_URI: string
+  export const WOOD_URI: string
+  /**
+   * chatwoot support widget
+   */
   export const CHATWOOT_URI: string
   export const LOGGING_WEBVIEW: 'false' | 'true' | undefined
 }


### PR DESCRIPTION
* updates to support all currently production, development, and ephemeral (individual development) environments
* renames for consistency with what DNS resolves to

to test - open sidebar in app, click settings, click settings heading 5 times, scroll down and click mobile environment button, click an environment - see that the URL is loaded in the metro logs.

![image](https://github.com/shapeshift/mobile-app/assets/88504456/c9f87f64-f018-4ce5-916d-4798793675de)