### PR TITLE
feat: provide currency format to the webview

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1275,9 +1275,11 @@ PODS:
     - React-Core
   - RNCClipboard (1.11.1):
     - React-Core
+  - RNLocalize (3.1.0):
+    - React-Core
   - RNScrypt (1.2.3):
     - React
-  - RNSVG (15.2.0):
+  - RNSVG (15.3.0):
     - React-Core
   - SocketRocket (0.7.0)
   - Yoga (0.0.0)
@@ -1354,6 +1356,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
+  - RNLocalize (from `../node_modules/react-native-localize`)
   - "RNScrypt (from `../node_modules/@seald-io/react-native-scrypt`)"
   - RNSVG (from `../node_modules/react-native-svg`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -1502,6 +1505,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCClipboard:
     :path: "../node_modules/@react-native-clipboard/clipboard"
+  RNLocalize:
+    :path: "../node_modules/react-native-localize"
   RNScrypt:
     :path: "../node_modules/@seald-io/react-native-scrypt"
   RNSVG:
@@ -1579,10 +1584,11 @@ SPEC CHECKSUMS:
   ReactCommon: f42444e384d82ab89184aed5d6f3142748b54768
   RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
   RNCClipboard: 2834e1c4af68697089cdd455ee4a4cdd198fa7dd
+  RNLocalize: e8694475db034bf601e17bd3dfa8986565e769eb
   RNScrypt: 2dcfcc34960afb8836c947b0510167a18ebb0a5a
-  RNSVG: 43b64ed39c14ce830d840903774154ca0c1f27ec
+  RNSVG: a48668fd382115bc89761ce291a81c4ca5f2fd2e
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: b9a182ab00cf25926e7f79657d08c5d23c2d03b0
+  Yoga: 348f8b538c3ed4423eb58a8e5730feec50bce372
 
 PODFILE CHECKSUM: 6687c540e4a593ffbb7a9ecac60bdcc639137081
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-native-dotenv": "latest",
     "react-native-error-boundary": "latest",
     "react-native-get-random-values": "~1.11.0",
+    "react-native-localize": "^3.1.0",
     "react-native-shake": "latest",
     "react-native-simple-crypto": "latest",
     "react-native-svg": "15.3.0",

--- a/src/lib/currencyFormat.ts
+++ b/src/lib/currencyFormat.ts
@@ -1,0 +1,8 @@
+/**
+ * Needed to change the default format configuration of the shapeshift web app
+ */
+import { getNumberFormatSettings } from 'react-native-localize'
+
+export const currencyFormatSettingsInjectedJavascript = `
+globalThis.mobileCurrencyFormat = ${JSON.stringify(getNumberFormatSettings())}
+`

--- a/src/lib/getMessageManager.ts
+++ b/src/lib/getMessageManager.ts
@@ -7,6 +7,7 @@ import { onConsole } from './console'
 import { makeKey } from './crypto/crypto'
 import { getWalletManager } from './getWalletManager'
 import { EventData, MessageManager } from './MessageManager'
+import { currencyFormatSettingsInjectedJavascript } from './currencyFormat'
 
 type EncryptedWalletInfo = {
   [k: string]: string
@@ -17,6 +18,7 @@ export const getMessageManager = once(() => {
 
   console.log('[App] Injecting clipboard JavaScript')
   messageManager.registerInjectedJavaScript(injectedJavaScriptClipboard)
+  messageManager.registerInjectedJavaScript(currencyFormatSettingsInjectedJavascript)
 
   const walletManager = getWalletManager()
 

--- a/src/lib/getMessageManager.ts
+++ b/src/lib/getMessageManager.ts
@@ -8,6 +8,7 @@ import { makeKey } from './crypto/crypto'
 import { getWalletManager } from './getWalletManager'
 import { EventData, MessageManager } from './MessageManager'
 import { currencyFormatSettingsInjectedJavascript } from './currencyFormat'
+import { injectMobilePlatform } from './injectPlatform'
 
 type EncryptedWalletInfo = {
   [k: string]: string
@@ -19,6 +20,7 @@ export const getMessageManager = once(() => {
   console.log('[App] Injecting clipboard JavaScript')
   messageManager.registerInjectedJavaScript(injectedJavaScriptClipboard)
   messageManager.registerInjectedJavaScript(currencyFormatSettingsInjectedJavascript)
+  messageManager.registerInjectedJavaScript(injectMobilePlatform)
 
   const walletManager = getWalletManager()
 

--- a/src/lib/injectPlatform.ts
+++ b/src/lib/injectPlatform.ts
@@ -1,0 +1,9 @@
+/**
+ * Needed to change the default format configuration of the shapeshift web app
+ */
+
+import { Platform } from 'react-native'
+
+export const injectMobilePlatform = `
+globalThis.mobilePlatform = ${JSON.stringify(Platform.OS)}
+`

--- a/yarn.lock
+++ b/yarn.lock
@@ -11236,6 +11236,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-localize@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "react-native-localize@npm:3.1.0"
+  peerDependencies:
+    react: ">=18.1.0"
+    react-native: ">=0.70.0"
+    react-native-macos: ">=0.70.0"
+  peerDependenciesMeta:
+    react-native-macos:
+      optional: true
+  checksum: 93753788facca7493b21056098f968217a53321d3324a467d4913f5b1b010cb4fde5e6107d538b84eae87ba9390c4a67a32d5a5fe54710b509b8097f1cf437ae
+  languageName: node
+  linkType: hard
+
 "react-native-quick-base64@npm:^2.0.5":
   version: 2.0.5
   resolution: "react-native-quick-base64@npm:2.0.5"
@@ -12112,6 +12126,7 @@ __metadata:
     react-native-dotenv: latest
     react-native-error-boundary: latest
     react-native-get-random-values: ~1.11.0
+    react-native-localize: ^3.1.0
     react-native-shake: latest
     react-native-simple-crypto: latest
     react-native-svg: 15.3.0


### PR DESCRIPTION
We need the mobile currency format to adapt the web currency formatter depending on the setting selected

The idea is to provide it to the window object my injecting some javascript, the same way we provide the `isShepaShiftMobile` variable. 

To be test with the web branch: 


