### PR TITLE
chore: allow use of localhost in simulator

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -13,6 +13,7 @@ GOME_URI=https://gome.shapeshift.com
 JUICE_URI=https://juice.shapeshift.com
 WOOD_URI=https://wood.shapeshift.com
 NEO_URI=https://neo.shapeshift.com
+LOCAL_URI=http://localhost:3000
 
 # used for support widget, a la intercom
 CHATWOOT_URI=https://app.chatwoot.com

--- a/src/components/DeveloperModeModal.tsx
+++ b/src/components/DeveloperModeModal.tsx
@@ -12,6 +12,7 @@ import {
   SHAPESHIFT_URI,
   WOOD_URI,
   YEET_URI,
+  LOCAL_URI,
 } from 'react-native-dotenv'
 import { setItemAsync } from 'expo-secure-store'
 import { styles } from '../styles'
@@ -91,7 +92,7 @@ const ENVIRONMENTS: Environment[] = [
   {
     key: 'localhost',
     title: 'localhost',
-    url: 'http://localhost:3000',
+    url: LOCAL_URI,
   },
 ]
 

--- a/src/lib/navigationFilter.ts
+++ b/src/lib/navigationFilter.ts
@@ -15,6 +15,7 @@ import {
   NEO_URI,
   WALLETCONNECT_VERIFY_SERVER,
   WALLETCONNECT_VERIFY_FALLBACK_SERVER,
+  LOCAL_URI,
 } from 'react-native-dotenv'
 
 const openBrowser = async (url: string) => {
@@ -40,7 +41,8 @@ export const shouldLoadFilter = (request: ShouldStartLoadRequest) => {
     request.url.startsWith(NEO_URI) ||
     request.url.startsWith(CHATWOOT_URI) ||
     request.url.startsWith(WALLETCONNECT_VERIFY_SERVER) ||
-    request.url.startsWith(WALLETCONNECT_VERIFY_FALLBACK_SERVER)
+    request.url.startsWith(WALLETCONNECT_VERIFY_FALLBACK_SERVER) ||
+    request.url.startsWith(LOCAL_URI)
   ) {
     return true
   }

--- a/types/react-native-dotenv.d.ts
+++ b/types/react-native-dotenv.d.ts
@@ -19,6 +19,7 @@ declare module 'react-native-dotenv' {
   export const JUICE_URI: string
   export const WOOD_URI: string
   export const NEO_URI: string
+  export const LOCAL_URI: string
   /**
    * chatwoot support widget
    */


### PR DESCRIPTION
Allows the use of localhost when running a simulated app build.

`shouldLoadFilter` was ignoring `localhost` so we just ended up with the browser version whenever we tried to connect to the local port.

Localhost env in device simulator now happy.

https://github.com/user-attachments/assets/ea61bbb6-50cc-4788-b8d8-0d97ea2034c9