### PR TITLE
fix: disable refresh and bounces scrolls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -204,10 +204,11 @@ const App = () => {
             style={loading ? styles.containerLoading : styles.container}
             allowsInlineMediaPlayback={true}
             mediaPlaybackRequiresUserAction={false}
-            pullToRefreshEnabled
+            pullToRefreshEnabled={false}
             decelerationRate={0.998}
             startInLoadingState
             javaScriptEnabled
+            bounces={false}
             domStorageEnabled
             scalesPageToFit
             originWhitelist={['*']}


### PR DESCRIPTION
We have weird scrolls that don't feel native at all but more like a browser, this PR disabled them

Also disabling the refresh feature as it shouldn't be intended and sometime users hits it for no reasons (me specially)

As well as this is adding a weird top scroll 