### PR TITLE
fix: set android target version so google is happy

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,6 +18,14 @@
         "backgroundColor": "#000b1f"
       }
     ],
+    [
+      "expo-build-properties",
+      {
+        "android": {
+          "targetSdkVersion": 35
+        }
+      }
+    ],
     ["./plugins/withCustomGradleProperties"]
   ],
   "android": {
@@ -33,7 +41,10 @@
   },
   "ios": {
     "bundleIdentifier": "com.shapeShift.shapeShift",
-    "supportsTablet": true
+    "supportsTablet": true,
+    "infoPlist": {
+      "ITSAppUsesNonExemptEncryption": false
+    }
   },
   "extra": {
     "eas": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-query": "^5.75.4",
     "bip39": "^3.0.4",
     "expo": "~53.0.7",
+    "expo-build-properties": "^0.14.8",
     "expo-clipboard": "^7.1.4",
     "expo-constants": "^17.1.5",
     "expo-local-authentication": "~16.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4882,6 +4882,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv@npm:^8.11.0":
+  version: 8.17.1
+  resolution: "ajv@npm:8.17.1"
+  dependencies:
+    fast-deep-equal: ^3.1.3
+    fast-uri: ^3.0.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+  checksum: 1797bf242cfffbaf3b870d13565bd1716b73f214bb7ada9a497063aada210200da36e3ed40237285f3255acc4feeae91b1fb183625331bad27da95973f7253d9
+  languageName: node
+  linkType: hard
+
 "anser@npm:^1.4.9":
   version: 1.4.10
   resolution: "anser@npm:1.4.10"
@@ -7110,6 +7122,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-build-properties@npm:^0.14.8":
+  version: 0.14.8
+  resolution: "expo-build-properties@npm:0.14.8"
+  dependencies:
+    ajv: ^8.11.0
+    semver: ^7.6.0
+  peerDependencies:
+    expo: "*"
+  checksum: 7aa59c8f62761230f3cb1c4f260b93ea2adbcf6d7056b4a2fa76be19b15374e0d9b4b1d8525053b93e4b011efeb58a1080a5d453fcdb9e141ad5cec5b52dc1dd
+  languageName: node
+  linkType: hard
+
 "expo-clipboard@npm:^7.1.4":
   version: 7.1.4
   resolution: "expo-clipboard@npm:7.1.4"
@@ -7427,6 +7451,13 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 92cfec0a8dfafd9c7a15fba8f2cc29cd0b62b85f056d99ce448bbcd9f708e18ab2764bda4dd5158364f4145a7c72788538994f0d1787b956ef0d1062b0f7c24c
+  languageName: node
+  linkType: hard
+
+"fast-uri@npm:^3.0.1":
+  version: 3.0.6
+  resolution: "fast-uri@npm:3.0.6"
+  checksum: 7161ba2a7944778d679ba8e5f00d6a2bb479a2142df0982f541d67be6c979b17808f7edbb0ce78161c85035974bde3fa52b5137df31da46c0828cb629ba67c4e
   languageName: node
   linkType: hard
 
@@ -9227,6 +9258,13 @@ __metadata:
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
   checksum: 7486074d3ba247769fda17d5181b345c9fb7d12e0da98b22d1d71a5db9698d8b4bd900a3ec1a4ffdd60846fc2556274a5c894d0c48795f14cb03aeae7b55260b
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-schema-traverse@npm:1.0.0"
+  checksum: 02f2f466cdb0362558b2f1fd5e15cce82ef55d60cd7f8fa828cf35ba74330f8d767fcae5c5c2adb7851fa811766c694b9405810879bc4e1ddd78a7c0e03658ad
   languageName: node
   linkType: hard
 
@@ -12135,6 +12173,7 @@ __metadata:
     eslint-plugin-react: ^7.31.8
     eslint-plugin-react-native: ^4.0.0
     expo: ~53.0.7
+    expo-build-properties: ^0.14.8
     expo-clipboard: ^7.1.4
     expo-constants: ^17.1.5
     expo-local-authentication: ~16.0.4


### PR DESCRIPTION
We have a warning that google want us to set our target SDK version to 35 at least or they might reject our app/remove it from the store, let's force it then... even thought maybe expo will take care of it automatically at some point, we absolutely don't want to be rejected from the store.

## testing steps
Generate the android folder with `npx expo prebuild`, check `gradle.properties` file inside it, it should have a target sdk 35