### PR TITLE
fix: add camera permission

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,7 +29,8 @@
       "backgroundColor": "#181C27"
     },
     "softwareKeyboardLayoutMode": "pan",
-    "blockedPermissions": ["android.permission.ACTIVITY_RECOGNITION"]
+    "blockedPermissions": ["android.permission.ACTIVITY_RECOGNITION"],
+    "permissions": ["android.permission.CAMERA"]
   },
   "ios": {
     "bundleIdentifier": "com.shapeShift.shapeShift",


### PR DESCRIPTION
Impossible to test locally as it works locally but assuming dev apps doesn't require permissions, and this was missing comparing with the previous version of the app, it should probably fix the EAS build, to be tested!