### PR TITLE
fix: ios camera permissions

### DIFF
--- a/app.json
+++ b/app.json
@@ -44,7 +44,8 @@
     "bundleIdentifier": "com.shapeShift.shapeShift",
     "supportsTablet": true,
     "infoPlist": {
-      "ITSAppUsesNonExemptEncryption": false
+      "ITSAppUsesNonExemptEncryption": false,
+      "NSCameraUsageDescription": "This app uses the camera to scan QR codes for addresses."
     }
   },
   "extra": {


### PR DESCRIPTION
I think we forgot to test the camera post deleting native folders, we might have killed the camera on iOS because of this, our native package doesn't have the camera permission anymore, let's bring it back