### PR TITLE
fix: new runtime version

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "ShapeShift",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "displayName": "ShapeShift",
   "icon": "./src/static/icon.png",
   "scheme": "shapeshift",
@@ -58,5 +58,5 @@
   "updates": {
     "url": "https://u.expo.dev/5fc55e72-5e61-41f2-be9b-01a77afc388e"
   },
-  "runtimeVersion": "3.3.0"
+  "runtimeVersion": "3.3.1"
 }

--- a/app.json
+++ b/app.json
@@ -58,5 +58,5 @@
   "updates": {
     "url": "https://u.expo.dev/5fc55e72-5e61-41f2-be9b-01a77afc388e"
   },
-  "runtimeVersion": "3.3.1"
+  "runtimeVersion": "3.3.0"
 }

--- a/eas.json
+++ b/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 9.0.8",
-    "appVersionSource": "remote"
+    "appVersionSource": "local"
   },
   "build": {
     "development": {

--- a/eas.json
+++ b/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 9.0.8",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {


### PR DESCRIPTION
Updating the versions from our app.json file as a quickwin, seems like EAS didn't take the minor version remotely, for some reasons... 

To unblock the current state, let's update our files, and see how we can somehow make it work magically afterwhile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Incremented application version to 3.3.1 to prepare a patch release.
  * Runtime version remains at 3.3.0 (no runtime behavior change).
  * No user-facing functionality changes; release focuses on distribution metadata and versioning consistency for smoother upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->