### PR TITLE
feat: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ EAS supports auto incrementing builds. Every time we submit a build, the patch v
 If we add some native library, we will need to prevent the old applications from receiving the Over-The-Air (OTA) updates:
 - The process is the same as updating to a major or minor version, but you also need to update the `runtimeVersion`, which is used by Expo to check if the `runtimeVersion` of the update is the same as the current OTA. If it differs, the application will not accept the OTA to avoid crash issues due to missing native files.
 
+### Pushing Over-The-Air Updates (OTAs)
+To deliver an OTA for the current version:
+```
+eas update --channel production --message "[message]"
+```
+We don't have any other channel than production.
+It will push OTAs to the devices having the current `runtimeVersion` installed, if users have old `runtimeVersion` they won't get the update (it means we probably updated some native files or anything that require a full release)
+
 ### Allow for OPS to test before releasing an OTA
 The more practical way is to update the `runtimeVersion` and push this particular build to android testing channels and flightests, but this will require a store update.
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,16 @@ If we add some native library, we will need to prevent the old applications from
 - The process is the same as updating to a major or minor version, but you also need to update the `runtimeVersion`, which is used by Expo to check if the `runtimeVersion` of the update is the same as the current OTA. If it differs, the application will not accept the OTA to avoid crash issues due to missing native files.
 
 ### Pushing Over-The-Air Updates (OTAs)
-To deliver an OTA for the current version:
-```
+
+To deliver an OTA for the current version, run:
+
+```shell
 eas update --channel production --message "[message]"
 ```
-We don't have any other channel than production.
-It will push OTAs to the devices having the current `runtimeVersion` installed, if users have old `runtimeVersion` they won't get the update (it means we probably updated some native files or anything that require a full release)
+
+We currently only use the production channel.
+Updates are delivered only to devices whose installed app has the same `runtimeVersion` as the update. Devices with an older `runtimeVersion` won't receive the OTA.
+See the [Expo docs on runtimeVersion](https://docs.expo.dev/eas-update/runtime-versions/) for details.
 
 ### Allow for OPS to test before releasing an OTA
 The more practical way is to update the `runtimeVersion` and push this particular build to android testing channels and flightests, but this will require a store update.


### PR DESCRIPTION
Adding the way to push OTAs in the readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section on pushing Over-The-Air (OTA) updates, including steps to deliver updates to the production channel and clarification that only devices on the current runtime version receive them.
  * Expanded notes on potential future channel strategies for operations.
  * Introduced a guide for releasing on the Solana dApp Store, covering validation and publishing steps using the store CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->