### PR TITLE
feat: add store review message

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "expo start",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "type-check": "tsc --project ./tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "expo-secure-store": "~14.2.3",
     "expo-splash-screen": "~0.30.10",
     "expo-status-bar": "^2.2.3",
+    "expo-store-review": "~8.1.5",
     "expo-updates": "~0.28.17",
     "lodash.memoize": "^4.1.2",
     "lodash.once": "^4.1.1",

--- a/src/lib/getMessageManager.ts
+++ b/src/lib/getMessageManager.ts
@@ -90,7 +90,7 @@ export const getMessageManager = once(() => {
     }
   })
 
-  messageManager.on('requestStoreReview', async() => {
+  messageManager.on('requestStoreReview', async () => {
     try {
       const available = await StoreReview.isAvailableAsync()
       const hasAction = await StoreReview.hasAction()

--- a/src/lib/getMessageManager.ts
+++ b/src/lib/getMessageManager.ts
@@ -2,6 +2,7 @@
 import * as Clipboard from 'expo-clipboard'
 import once from 'lodash.once'
 import { injectedJavaScript as injectedJavaScriptClipboard } from './clipboard'
+import * as StoreReview from 'expo-store-review';
 
 import { onConsole } from './console'
 import { makeKey } from './crypto/crypto'
@@ -87,6 +88,10 @@ export const getMessageManager = once(() => {
         console.warn('[haptics] Unknown or missing level:', level, '- defaulting to Medium')
         return Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)
     }
+  })
+
+  messageManager.on('requestStoreReview', () => {
+    return StoreReview.requestReview()
   })
 
   /**

--- a/src/lib/getMessageManager.ts
+++ b/src/lib/getMessageManager.ts
@@ -2,7 +2,7 @@
 import * as Clipboard from 'expo-clipboard'
 import once from 'lodash.once'
 import { injectedJavaScript as injectedJavaScriptClipboard } from './clipboard'
-import * as StoreReview from 'expo-store-review';
+import * as StoreReview from 'expo-store-review'
 
 import { onConsole } from './console'
 import { makeKey } from './crypto/crypto'

--- a/src/lib/getMessageManager.ts
+++ b/src/lib/getMessageManager.ts
@@ -90,8 +90,20 @@ export const getMessageManager = once(() => {
     }
   })
 
-  messageManager.on('requestStoreReview', () => {
-    return StoreReview.requestReview()
+  messageManager.on('requestStoreReview', async() => {
+    try {
+      const available = await StoreReview.isAvailableAsync()
+      const hasAction = await StoreReview.hasAction()
+
+      if (!available) return false
+      if (!hasAction) return false
+
+      await StoreReview.requestReview()
+      return true
+    } catch (e) {
+      console.error('[requestStoreReview:Error]', e)
+      return false
+    }
   })
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -10328,6 +10328,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-store-review@npm:~8.1.5":
+  version: 8.1.5
+  resolution: "expo-store-review@npm:8.1.5"
+  peerDependencies:
+    expo: "*"
+    react-native: "*"
+  checksum: 8c53edc8c9116e7a5f38592fc446b26f0d15a9a59a3106e9bdc8cc7af9ad2f0e0ba1cff579ebda6152ff3752b07e0b4165ec2ce2a0771dd3fd311b90a7fd25e7
+  languageName: node
+  linkType: hard
+
 "expo-structured-headers@npm:~4.1.0":
   version: 4.1.0
   resolution: "expo-structured-headers@npm:4.1.0"
@@ -16025,6 +16035,7 @@ __metadata:
     expo-secure-store: ~14.2.3
     expo-splash-screen: ~0.30.10
     expo-status-bar: ^2.2.3
+    expo-store-review: ~8.1.5
     expo-updates: ~0.28.17
     jest: ^29.4.0
     lodash.memoize: ^4.1.2


### PR DESCRIPTION
Does what it says, adds the expo store review library and expose it through a new message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - In-app store review prompts: users can rate the app natively on supported platforms without leaving the app.

- **Chores**
  - Added the platform dependency required for in-app review capability.
  - Added a lint autofix script to help automatically correct code style issues during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->