### PR TITLE
feat: add app version message

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "ShapeShift",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "displayName": "ShapeShift",
   "icon": "./src/static/icon.png",
   "scheme": "shapeshift",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-query": "^5.75.4",
     "bip39": "^3.0.4",
     "expo": "^53.0.20",
+    "expo-application": "^6.1.5",
     "expo-build-properties": "^0.14.8",
     "expo-clipboard": "~7.1.5",
     "expo-constants": "~17.1.7",

--- a/src/lib/getMessageManager.ts
+++ b/src/lib/getMessageManager.ts
@@ -3,6 +3,7 @@ import * as Clipboard from 'expo-clipboard'
 import once from 'lodash.once'
 import { injectedJavaScript as injectedJavaScriptClipboard } from './clipboard'
 import * as StoreReview from 'expo-store-review'
+import * as Application from 'expo-application';
 
 import { onConsole } from './console'
 import { makeKey } from './crypto/crypto'
@@ -103,6 +104,13 @@ export const getMessageManager = once(() => {
     } catch (e) {
       console.error('[requestStoreReview:Error]', e)
       return false
+    }
+  })
+
+  messageManager.on('getAppVersion', () => {
+    return {
+      version: Application.nativeApplicationVersion,
+      buildNumber: Application.nativeBuildVersion,
     }
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10125,6 +10125,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-application@npm:^6.1.5":
+  version: 6.1.5
+  resolution: "expo-application@npm:6.1.5"
+  peerDependencies:
+    expo: "*"
+  checksum: d3a86e0841c3626dc7819bd3e35f313ad682f13705be2b640adc5aa96acab837e80cabf025768a082ed1cf2ad8190ce9c5e627cc9f5a3ed09886b42ea7443c3b
+  languageName: node
+  linkType: hard
+
 "expo-asset@npm:~11.1.7":
   version: 11.1.7
   resolution: "expo-asset@npm:11.1.7"
@@ -16026,6 +16035,7 @@ __metadata:
     eslint-plugin-react: ^7.31.8
     eslint-plugin-react-native: ^4.0.0
     expo: ^53.0.20
+    expo-application: ^6.1.5
     expo-build-properties: ^0.14.8
     expo-clipboard: ~7.1.5
     expo-constants: ~17.1.7


### PR DESCRIPTION
Again does what it says, allow the webapp to query the app version, so we can enable and disable feature depending on the version