### PR TITLE
fix: prevent workflows to run 2 time when merging on main

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,9 +3,6 @@ name: Lint
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workflows are running 2 times when merging a PR, let's avoid using more compute from EAS and upping the build too much for nothing!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration updated to run only on pushes to the main branch; pull request triggers removed. Existing lint checks remain unchanged. This affects build and verification workflows only. No changes to features, performance, or behavior of the application. No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->