### PR TITLE
fix: deep links (maybe)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,8 +130,20 @@ const App = () => {
        * ?Date.now() tricks the webview into navigating to a different url.
        * without it, the urls are the same, even if the webview has routed
        * to some other page within the webview.
+       *
+       * We need to check if the path already contains query params to avoid
+       * creating invalid URLs with multiple '?' characters.
+       *
+       * Examples:
+       * Input:  shapeshift://trade
+       * Output: http://192.168.1.111:3000/#/trade?1761049856014
+       *
+       * Input:  shapeshift://wc?uri=wc%3A123...
+       * Before: http://192.168.1.111:3000/#/wc?uri=wc%3A123...?1761049856014 (INVALID - two ?)
+       * After:  http://192.168.1.111:3000/#/wc?uri=wc%3A123...&1761049856014 (VALID - uses &)
        */
-      const newUri = `${settings?.EXPO_PUBLIC_SHAPESHIFT_URI}/#/${path}?${Date.now()}`
+      const timestampParam = path.includes('?') ? '&' : '?'
+      const newUri = `${settings?.EXPO_PUBLIC_SHAPESHIFT_URI}/#/${path}${timestampParam}${Date.now()}`
       console.log('newUri', newUri, URL_DELIMITER, url)
       setUri(newUri)
     }


### PR DESCRIPTION
### Description

When deep links contain query parameters (e.g., shapeshift://wc?uri=...), the timestamp trick was adding a second '?' instead of '&', breaking URL parsing.

Before: /#/wc?uri=...?1234567890 (invalid)
After:  /#/wc?uri=...&1234567890 (valid)

This fixes WalletConnect deep link handling where the URI parameter was not being parsed correctly in the web app.

### Testing

⚠️ Untested because of env shenanigans, @NeOMakinG to test

- Run *akschual* expo build, *not* expo, since this assumes `shapeshift://` deep links
- Run `xcrun simctl openurl booted "<yourShapeshiftDeepLink>"` , with deep link URL gotten from https://github.com/shapeshift/web/pull/10873 test html file under mobile section 
  <img width="723" height="291" alt="image" src="https://github.com/user-attachments/assets/bbef7f02-42e3-4039-8cfa-8e17691889f3" />
- Ensure deep linking does work from mobile app (not 100% sure this fixes routing for mobile app, but at the very least, if you run RN Devtools with `j` then you should see proper URI with first `?` and subsequent `&` in navigation logs)


### Issue

- closes https://github.com/shapeshift/web/issues/10832

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":""}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL construction to properly handle deep links with existing query parameters, preventing malformed URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->