### PR TITLE
fix: attempt at fixing apple ads auto linking module

### DIFF
--- a/modules/expo-apple-ads/expo-module.config.json
+++ b/modules/expo-apple-ads/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android"],
+  "platforms": ["apple", "android"],
   "apple": {
     "modules": ["ExpoAppleAdsModule"],
     "podspecPath": "ExpoAppleAds.podspec"


### PR DESCRIPTION
It seems we were using a wrong key in our apple ads module configuration, I guess this is the reasons why auto linking didn't work in the last build (I hope so..)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform configuration for the Apple Ads module to align platform identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->