### PR TITLE
fix: remove android and handle error

### DIFF
--- a/modules/expo-apple-ads/expo-module.config.json
+++ b/modules/expo-apple-ads/expo-module.config.json
@@ -2,8 +2,5 @@
   "platforms": ["apple"],
   "apple": {
     "modules": ["ExpoAppleAdsModule"]
-  },
-  "android": {
-    "modules": ["expo.modules.appleads.ExpoAppleAdsModule"]
   }
 }

--- a/modules/expo-apple-ads/src/index.ts
+++ b/modules/expo-apple-ads/src/index.ts
@@ -1,9 +1,9 @@
 import { requireNativeModule } from 'expo-modules-core'
 
-const ExpoAppleAdsModule = requireNativeModule('ExpoAppleAds')
 
 export async function getAttributionToken(): Promise<string | null> {
   try {
+    const ExpoAppleAdsModule = requireNativeModule('ExpoAppleAds')
     const token = await ExpoAppleAdsModule.getAttributionToken()
     return token
   } catch (error) {


### PR DESCRIPTION
Remove android from the apple ads module and handle if the module isn't registered so its not throwing if we try to import it in the mobile app

Already testable using the internal channel on android, it doesnt crash anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of the Apple Ads module, now Apple platform only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->