### PR TITLE
feat(mobile): add expo-apple-ads iOS native implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,8 +96,8 @@ web-build/
 expo-env.d.ts
 # @end expo-cli
 
-android
-ios
+/android
+/ios
 
 # Keypair to publish to solana store
 keypair.json

--- a/modules/expo-apple-ads/ios/ExpoAppleAds.podspec
+++ b/modules/expo-apple-ads/ios/ExpoAppleAds.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name           = 'ExpoAppleAds'
+  s.version        = '1.0.0'
+  s.summary        = 'Apple Search Ads attribution for Expo'
+  s.description    = 'Provides access to Apple\'s AdServices API for attribution tokens'
+  s.author         = 'ShapeShift'
+  s.homepage       = 'https://shapeshift.com'
+  s.platforms      = { :ios => '14.3' }
+  s.source         = { :git => '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.source_files = '**/*.swift'
+  s.frameworks = 'AdServices'
+end

--- a/modules/expo-apple-ads/ios/ExpoAppleAdsModule.swift
+++ b/modules/expo-apple-ads/ios/ExpoAppleAdsModule.swift
@@ -1,0 +1,23 @@
+import ExpoModulesCore
+import AdServices
+
+public class ExpoAppleAdsModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("ExpoAppleAds")
+
+    AsyncFunction("getAttributionToken") { () -> String? in
+      if #available(iOS 14.3, *) {
+        do {
+          let token = try AAAttribution.attributionToken()
+          return token
+        } catch {
+          print("[ExpoAppleAds] Error getting attribution token: \(error)")
+          return nil
+        }
+      } else {
+        print("[ExpoAppleAds] AdServices requires iOS 14.3+")
+        return nil
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Add ExpoAppleAds.podspec for CocoaPods integration
- Add ExpoAppleAdsModule.swift with AdServices attribution token support
- Update .gitignore to use /ios and /android patterns (root only)

This fixes the pod install error where the iOS native code was missing.

<img width="1290" height="229" alt="Screenshot 2025-12-15 at 4 36 46 pm" src="https://github.com/user-attachments/assets/de54ea48-028b-4f6a-9672-df03ca2d7298" />

@NeOMakinG I suspect you didn't notice because you have the missing files locally already, but they need to be committed.
Please review and confirm that the committed files match what you have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple Search Ads attribution support for iOS 14.3+, enabling apps to retrieve attribution tokens for ad tracking purposes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->