### PR TITLE
chore: bump version

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "ShapeShift",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "displayName": "ShapeShift",
   "icon": "./src/static/icon.png",
   "scheme": "shapeshift",
@@ -93,5 +93,5 @@
   "updates": {
     "url": "https://u.expo.dev/5fc55e72-5e61-41f2-be9b-01a77afc388e"
   },
-  "runtimeVersion": "3.6.0"
+  "runtimeVersion": "3.6.1"
 }


### PR DESCRIPTION
We need to bump version to be able to submit the build to iOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch release version 3.6.1 now available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->