### PR TITLE
fix: ios crashing because of seeker lib

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "ShapeShift",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "displayName": "ShapeShift",
   "icon": "./src/static/icon.png",
   "scheme": "shapeshift",
@@ -100,5 +100,5 @@
   "updates": {
     "url": "https://u.expo.dev/5fc55e72-5e61-41f2-be9b-01a77afc388e"
   },
-  "runtimeVersion": "3.7.1"
+  "runtimeVersion": "3.7.2"
 }

--- a/src/hooks/useSeekerWallet.tsx
+++ b/src/hooks/useSeekerWallet.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { getMessageManager } from '../lib/getMessageManager'
 import { getSeekerWalletManager } from '../lib/getSeekerWalletManager'
+import { Platform } from 'react-native'
 
 /**
  * Hook to handle Seeker wallet communication with the WebView
@@ -21,6 +22,10 @@ export const useSeekerWallet = () => {
   const seekerManager = getSeekerWalletManager()
 
   useEffect(() => {
+    if (Platform.OS !== 'android') {
+      return
+    }
+
     // Check availability on mount
     void seekerManager.checkAvailability().then(available => {
       setIsAvailable(available)
@@ -29,6 +34,10 @@ export const useSeekerWallet = () => {
   }, [seekerManager])
 
   useEffect(() => {
+    if (Platform.OS !== 'android') {
+      return
+    }
+
     /**
      * Check if Seeker/MWA wallet is available on this device
      */

--- a/src/lib/SeekerWalletManager.ts
+++ b/src/lib/SeekerWalletManager.ts
@@ -10,7 +10,8 @@ import {
   PURPOSE_SIGN_SOLANA_TRANSACTION,
 } from '../../modules/expo-seed-vault/src'
 import { checkSeedVaultPermission, requestSeedVaultPermission } from './requestSeedVaultPermission'
-import { transact } from '@solana-mobile/mobile-wallet-adapter-protocol-web3js'
+// NOTE: @solana-mobile/mobile-wallet-adapter-protocol-web3js is Android-only.
+// Always use dynamic import() to avoid crashing on iOS at module load time.
 
 /**
  * Seeker Wallet Manager - POC Implementation
@@ -219,6 +220,8 @@ export class SeekerWalletManager {
     }
 
     try {
+      const { transact } = await import('@solana-mobile/mobile-wallet-adapter-protocol-web3js')
+
       const result = await transact(async wallet => {
         const authResult = await wallet.authorize({
           identity: APP_IDENTITY,


### PR DESCRIPTION
iOS was crashing because we were trying to initiate the seeker wallet manager but this is importing a library that is trying to get an android module, we need to guard that to avoid the crash!

## How to test
run `yarn expo ios` and verify in the emulator that the app is not crashing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 3.7.2

* **Bug Fixes**
  * Resolved critical iOS stability issue preventing proper wallet functionality that could cause unexpected app crashes
  * Seeker wallet feature is now available exclusively on Android devices for optimal compatibility and performance
  * Improved platform-specific runtime handling to enhance app stability and reliability across all supported platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->